### PR TITLE
Dataset Additional Information Table

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/DatasetAdditionalInformation/index.jsx
+++ b/src/components/DatasetAdditionalInformation/index.jsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { Link } from '@reach/router';
+import { Table, TableHead, TableRow, TableCell, TableBody } from '@cmsgov/design-system';
+
+const DatasetAdditionalInformation = ({ datasetInfo }) => {
+  const {
+    accessLevel,
+    programCode,
+    issued,
+    modified,
+    keyword,
+    identifier,
+    theme,
+    contactPoint,
+    bureauCode,
+    publisher
+  } = datasetInfo;
+
+  const tags = keyword.map((k, index) => {
+    if(index === 0) {
+      return (<Link key={k.data} to={`/datasets?keyword[]=${k.data}`}>{k.data}</Link>);
+    } else {
+      return (<>, <Link key={k.data} to={`/datasets?keyword[]=${k.data}`}>{k.data}</Link></>);
+    }
+  })
+
+  return(
+    <div className="dc-c-additional-info-table ds-u-margin-bottom--3">
+      <h2>Additional Information</h2>
+      <Table compact striped>
+        <TableHead>
+          <TableRow>
+            <TableCell>Field</TableCell>
+            <TableCell>Value</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          <TableRow>
+            <TableCell>Last Update</TableCell>
+            <TableCell>{modified}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Issued</TableCell>
+            <TableCell>{issued}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Publisher</TableCell>
+            <TableCell>{publisher.data.name}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Identifier</TableCell>
+            <TableCell>{identifier}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Contact</TableCell>
+            <TableCell>{contactPoint.fn}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Contact Email</TableCell>
+            <TableCell>{contactPoint.hasEmail}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Bureau Code</TableCell>
+            <TableCell>{bureauCode[0]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Program Code</TableCell>
+            <TableCell>{programCode[0]}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Category</TableCell>
+            <TableCell>{theme.map(t => t.data).join(',')}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Tags</TableCell>
+            <TableCell>{tags}</TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>License</TableCell>
+            <TableCell></TableCell>
+          </TableRow>
+          <TableRow>
+            <TableCell>Public Access Level</TableCell>
+            <TableCell>{accessLevel}</TableCell>
+          </TableRow>
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export default DatasetAdditionalInformation;

--- a/src/components/DatasetAdditionalInformation/index.jsx
+++ b/src/components/DatasetAdditionalInformation/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from '@reach/router';
 import { Table, TableHead, TableRow, TableCell, TableBody } from '@cmsgov/design-system';
+import TransformedDate from '../TransformedDate';
 
 const DatasetAdditionalInformation = ({ datasetInfo }) => {
   const {
@@ -37,11 +38,11 @@ const DatasetAdditionalInformation = ({ datasetInfo }) => {
         <TableBody>
           <TableRow>
             <TableCell>Last Update</TableCell>
-            <TableCell>{modified}</TableCell>
+            <TableCell><TransformedDate date={modified} /></TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Issued</TableCell>
-            <TableCell>{issued}</TableCell>
+            <TableCell><TransformedDate date={issued} /></TableCell>
           </TableRow>
           <TableRow>
             <TableCell>Publisher</TableCell>

--- a/src/components/DatasetTags/index.jsx
+++ b/src/components/DatasetTags/index.jsx
@@ -5,7 +5,7 @@ import { Link } from '@reach/router';
 const DatasetTags = ({ keywords }) => {
   return (
     <div className="dc-c-dataset-tags ds-u-margin-bottom--3 ds-u-padding--2 ds-u-border ds-u-border--1">
-      <h2 className="ds-u-font-size--h2 ds-u-margin-bottom--2">Tags</h2>
+      <h2 className="ds-u-font-size--h2 ds-u-margin-bottom--2 ds-u-margin-top--0">Tags</h2>
       {keywords
         && keywords.map(
           (k) => (

--- a/src/components/TransformedDate/index.jsx
+++ b/src/components/TransformedDate/index.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const TransformedDate = ({date, options}) => {
+  const rawDate = new Date(date);
+  let modifiedDate = '';
+  if(rawDate) {
+    modifiedDate = rawDate.toLocaleDateString('en-US', options);
+  }
+  return(
+    <>
+      {modifiedDate}
+    </>
+  );
+}
+
+TransformedDate.defaultProps = {
+  options: {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  }
+}
+
+export default TransformedDate;

--- a/src/styles/scss/components/additional-information-table.scss
+++ b/src/styles/scss/components/additional-information-table.scss
@@ -1,0 +1,5 @@
+.dc-c-additional-info-table {
+  table {
+    width: 100%;
+  }
+}

--- a/src/styles/scss/components/index.scss
+++ b/src/styles/scss/components/index.scss
@@ -4,3 +4,4 @@
 @import "./pagination.scss";
 @import "./dataset-search-list-item.scss";
 @import "./dataset-search-facets.scss";
+@import "./additional-information-table.scss";

--- a/src/templates/Dataset/index.jsx
+++ b/src/templates/Dataset/index.jsx
@@ -7,6 +7,7 @@ import ResourcePreview from '../../components/ResourcePreview';
 import ResourceHeader from '../../components/ResourceHeader';
 import DatasetTags from '../../components/DatasetTags';
 import DatasetDownloads from '../../components/DatasetDownloads';
+import DatasetAdditionalInformation from '../../components/DatasetAdditionalInformation';
 
 const Dataset = ({ id, rootUrl }) => {
   const resourceOptions = {
@@ -33,7 +34,7 @@ const Dataset = ({ id, rootUrl }) => {
             <p className="ds-l-col--4">Updated {modifiedDate}</p>
           </div>
           <p>{dataset.description}</p>
-          <h2>Dataset Explorer</h2>
+          <h2>Resource Preview</h2>
           {dataset.distribution
             && (
               <Resource
@@ -51,6 +52,9 @@ const Dataset = ({ id, rootUrl }) => {
                 {/* <ResourceFooter /> */}
               </Resource>
             )
+          }
+          {dataset.identifier &&
+            <DatasetAdditionalInformation datasetInfo={dataset} />
           }
         </div>
         <div className="ds-l-col--4">

--- a/src/templates/Dataset/index.jsx
+++ b/src/templates/Dataset/index.jsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from '@reach/router';
 import { useMetastoreDataset, Resource, prepareColumns } from '@civicactions/data-catalog-services';
 import { Badge } from '@cmsgov/design-system';
 import ResourcePreview from '../../components/ResourcePreview';
@@ -8,6 +7,7 @@ import ResourceHeader from '../../components/ResourceHeader';
 import DatasetTags from '../../components/DatasetTags';
 import DatasetDownloads from '../../components/DatasetDownloads';
 import DatasetAdditionalInformation from '../../components/DatasetAdditionalInformation';
+import TransformedDate from '../../components/TransformedDate';
 
 const Dataset = ({ id, rootUrl }) => {
   const resourceOptions = {
@@ -31,7 +31,7 @@ const Dataset = ({ id, rootUrl }) => {
             <p className="ds-l-col--8">
               {dataset.theme ? <Badge>{dataset.theme[0].data}</Badge> : null}
             </p>
-            <p className="ds-l-col--4">Updated {modifiedDate}</p>
+            <p className="ds-l-col--4">Updated <TransformedDate date={modifiedDate} /></p>
           </div>
           <p>{dataset.description}</p>
           <h2>Resource Preview</h2>


### PR DESCRIPTION
This adds a CMS Design system table for the additional information section of the dataset page. It uses a basic table since there is no need for all the features of a data preview and it's only 2 columns. 