### PR TITLE
Hide auth with prop on API page

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/templates/APIPage/index.jsx
+++ b/src/templates/APIPage/index.jsx
@@ -3,7 +3,7 @@ import SwaggerUI from 'swagger-ui-react';
 
 const APIPage = () => (
   <section className="ds-l-container">
-    <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}?authentication=false`} docExpansion={'list'} />;
+    <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}`} docExpansion={'list'} />;
   </section>
 );
 

--- a/src/templates/APIPage/index.jsx
+++ b/src/templates/APIPage/index.jsx
@@ -1,10 +1,14 @@
 import React from 'react';
 import SwaggerUI from 'swagger-ui-react';
 
-const APIPage = () => (
+const APIPage = ({hideAuth}) => (
   <section className="ds-l-container">
-    <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}`} docExpansion={'list'} />;
+    <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}${hideAuth ? '?authentication=false' : ''}`} docExpansion={'list'} />;
   </section>
 );
+
+APIPage.defaultProps = {
+  hideAuth: false,
+}
 
 export default APIPage;


### PR DESCRIPTION
Instead of always hiding the authentication part of the api docs, there is now a prop to opt out of it. 