### PR TITLE
WCMS-4632 

### DIFF
--- a/src/components/Breadcrumb/index.jsx
+++ b/src/components/Breadcrumb/index.jsx
@@ -16,9 +16,11 @@ const Breadcrumb = ({ currentPage, pageTrail = [] }) => {
     <nav class="dc-c-breadcrumb ds-u-margin-top--6" aria-label="Breadcrumbs">
       <ol class="dc-c-breadcrumb__list">
         {pageTrailContent}
-        <li class="dc-c-breadcrumb__list-item dc-c-current" aria-current="page">
-          <span>{currentPage}</span>
-        </li>
+        {currentPage ? (
+          <li class="dc-c-breadcrumb__list-item dc-c-current" aria-current="page">
+            <span>{currentPage}</span>
+          </li>
+        ) : ''}
       </ol>
     </nav>
   );


### PR DESCRIPTION
updated breadcrumb to not print current page if empty string is passed.