### PR TITLE
WCMS-4890: set timezone to UTC to avoid conversions.

### DIFF
--- a/src/components/TransformedDate/index.jsx
+++ b/src/components/TransformedDate/index.jsx
@@ -18,6 +18,7 @@ TransformedDate.defaultProps = {
     year: 'numeric',
     month: 'long',
     day: 'numeric',
+    timeZone: "UTC"
   }
 }
 

--- a/src/templates/Dataset/DatasetBody.jsx
+++ b/src/templates/Dataset/DatasetBody.jsx
@@ -31,12 +31,6 @@ const DatasetBody = ({ id, dataset }) => {
     }
   }, [distribution])
 
-  const rawDate = new Date(dataset.modified);
-  let modifiedDate = '';
-  let options = { year: 'numeric', month: 'long', day: 'numeric' };
-  if(rawDate) {
-    modifiedDate = rawDate.toLocaleDateString('en-US', options);
-  }
   return (
     <section className="ds-l-container">
       <div className="ds-l-row ds-u-padding-top--3">
@@ -46,7 +40,7 @@ const DatasetBody = ({ id, dataset }) => {
             <p className="ds-l-col--6">
               {dataset.theme ? <Badge variation="info">{dataset.theme[0].data}</Badge> : null}
             </p>
-            <p className="ds-l-col--6 ds-u-color--gray ds-u-text-align--right">Updated <TransformedDate date={modifiedDate} /></p>
+            <p className="ds-l-col--6 ds-u-color--gray ds-u-text-align--right">Updated <TransformedDate date={dataset.modified} /></p>
           </div>
           <p dangerouslySetInnerHTML={{__html: dataset.description}} />
           <h2 className="dc-resource-header">Resource Preview</h2>


### PR DESCRIPTION
This is done because we are assuming that Drupal is handling all timezone implications before the string gets sent to us via the API.