### PR TITLE
Reduce margin a bit on hader to stop wrapping on open payments

### DIFF
--- a/src/templates/header/index.jsx
+++ b/src/templates/header/index.jsx
@@ -57,9 +57,9 @@ const Header = ({
               menuName="CMS Site Main Nav"
               menuId="site"
               menuClasses="ds-u-display--flex dc-c-header--links ds-u-align-items--center"
-              linkClasses="ds-u-margin-right--4 ds-u-padding-y--3"
+              linkClasses="ds-u-xl-margin-right--4 ds-u-margin-right--3 ds-u-padding-y--3"
             />
-            <div className="dc-c-main-navigation--search ds-u-margin-left--auto ds-u-padding-left--3">
+            <div className="dc-c-main-navigation--search ds-u-margin-left--auto ds-u-lg-padding-left--1 ds-u-xl-padding-left--3">
               {customSearch ? (
                 customSearch
               ) : (

--- a/src/templates/header/index.jsx
+++ b/src/templates/header/index.jsx
@@ -57,7 +57,7 @@ const Header = ({
               menuName="CMS Site Main Nav"
               menuId="site"
               menuClasses="ds-u-display--flex dc-c-header--links ds-u-align-items--center"
-              linkClasses="ds-u-margin-right--5 ds-u-padding-y--3"
+              linkClasses="ds-u-margin-right--4 ds-u-padding-y--3"
             />
             <div className="dc-c-main-navigation--search ds-u-margin-left--auto ds-u-padding-left--3">
               {customSearch ? (


### PR DESCRIPTION
On sites with multiple sub nav menus, the search button on the top right was being pushed down a row on desktop view. 