### PR TITLE
Removes schema from Swagger component calls

### DIFF
--- a/src/templates/APIPage/index.jsx
+++ b/src/templates/APIPage/index.jsx
@@ -3,7 +3,11 @@ import SwaggerUI from 'swagger-ui-react';
 
 const APIPage = ({hideAuth, additionalParams}) => (
   <section className="ds-l-container">
-    <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}?${hideAuth ? 'authentication=false&' : ''}${additionalParams && additionalParams.ACA ? 'ACA=' + additionalParams.ACA + '&redirect=false' : ''}`} docExpansion={'list'} />
+    <SwaggerUI
+      url={`${process.env.REACT_APP_ROOT_URL}?${hideAuth ? 'authentication=false&' : ''}${additionalParams && additionalParams.ACA ? 'ACA=' + additionalParams.ACA + '&redirect=false' : ''}`}
+      docExpansion={'list'}
+      defaultModelsExpandDepth={-1}
+      />
   </section>
 );
 

--- a/src/templates/Dataset/DatasetBody.jsx
+++ b/src/templates/Dataset/DatasetBody.jsx
@@ -89,7 +89,11 @@ const DatasetBody = ({ id, dataset, additionalParams }) => {
           {Object.keys(distribution).length && fileFormat === "CSV" && dataset.identifier ? (
             <div ref={apiDocs}>
               <h2>Try the API</h2>
-              <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${dataset.identifier}/docs${additionalParams && additionalParams.ACA ? '?ACA=' + additionalParams.ACA + '&redirect=false' : ''}`} docExpansion={'list'} />
+              <SwaggerUI
+                url={`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${dataset.identifier}/docs${additionalParams && additionalParams.ACA ? '?ACA=' + additionalParams.ACA + '&redirect=false' : ''}`}
+                docExpansion={'list'}
+                defaultModelsExpandDepth={-1}
+                />
             </div>
             ) : ''
           }

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -134,7 +134,11 @@ const FilteredResourceBody = ({id, dataset, distIndex, location, apiDocPage, add
             {dataset.identifier &&
               <div ref={apiDocs}>
                 <h2>Try the API</h2>
-                <SwaggerUI url={`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${dataset.identifier}/docs${additionalParams && additionalParams.ACA ? '?ACA=' + additionalParams.ACA + '&redirect=false' : ''}`} docExpansion={'list'} />
+                <SwaggerUI
+                  url={`${process.env.REACT_APP_ROOT_URL}/metastore/schemas/dataset/items/${dataset.identifier}/docs${additionalParams && additionalParams.ACA ? '?ACA=' + additionalParams.ACA + '&redirect=false' : ''}`} 
+                  docExpansion={'list'}
+                  defaultModelsExpandDepth={-1}
+                  />
               </div>
             }
           </>


### PR DESCRIPTION
Removes the schema from the instances of swagger on the /api page, dataset page and filtered resource page. 