### PR TITLE
Fix % not removed when switching between is/contains

### DIFF
--- a/src/components/ResourceFilter/index.jsx
+++ b/src/components/ResourceFilter/index.jsx
@@ -43,6 +43,7 @@ const ResourceFilter = ({id, filterOpen, setFilterOpen, defaultCondition, resour
     e.preventDefault();
     if(formConditions.length) {
       const updatedConditions = formConditions.map((cond) => {
+        cond.value = cond.value.replace(/(^\%+|\%+$)/mg, '');
         if(cond.operator.toLowerCase() === 'like') {
           const cleanedValue = cond.value.replace(/(^\%+|\%+$)/mg, '');
           cond.value = `%${cleanedValue}%`;


### PR DESCRIPTION
Previously there was a fix added to trim the `%` on either side of the value in the text box when switching between is and contains filters on the filtered resource. This actually needed to be extended to the url/api requests too as it was sending an `=` condition with the percent signs still. 

The fix just cleans the code to only the value before setting the condition each time. This will need to be updated to include any other special characters we might add in the future. 