### PR TITLE
Update CSV download link to use dataset id and dist index

### DIFF
--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -36,7 +36,7 @@ const FilteredResourceBody = ({id, dataset, distIndex, location, apiDocPage, add
       resource.setManual(false)
     }
   }, [distribution])
-  const downloadUrl = `${process.env.REACT_APP_ROOT_URL}/datastore/query/${distribution.identifier}/download?${qs.stringify({conditions: resource.conditions}, { encode: true })}&format=csv`;
+  const downloadUrl = `${process.env.REACT_APP_ROOT_URL}/datastore/query/${id}/${distIndex}/download?${qs.stringify({conditions: resource.conditions}, { encode: true })}&format=csv`;
 
   return (
     <section className="ds-l-container ds-u-padding-bottom--3 ds-u-margin-bottom--2">


### PR DESCRIPTION
This fixes an issue where a download csv link would be broken if the dataset is refreshed/updated as its distribution id will change per update. The use case for this happening would only be if the link had been shared via 3rd party sites or in an email, the link would normally be created per page load so on the data catalog the old link was fine even after a dataset refresh. 