### PR TITLE
Update components with tealium requirements

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.1.0",
+  "version": "1.2.0-alpha.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/templates/Dataset/index.jsx
+++ b/src/templates/Dataset/index.jsx
@@ -1,13 +1,21 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useMetastoreDataset } from '@civicactions/data-catalog-services';
 import DatasetBody from './DatasetBody';
 import PageNotFound from '../PageNotFound';
 
 
-const Dataset = ({ id, rootUrl, additionalParams, customColumns }) => {
+const Dataset = ({ id, rootUrl, additionalParams, customColumns, setDatasetTitle }) => {
   const metastore = useMetastoreDataset(id, rootUrl, additionalParams);
   const { dataset } = metastore;
+  const title = dataset.title ? dataset.title : "";
+  useEffect(() => {
+    if(title) {
+      if(setDatasetTitle) {
+        setDatasetTitle(title);
+      }
+    }
+  }, [title])
   const notFoundContent = (
     <>
       <h1>Error: Dataset not found</h1>

--- a/src/templates/FilteredResource/index.jsx
+++ b/src/templates/FilteredResource/index.jsx
@@ -3,7 +3,7 @@ import { useMetastoreDataset } from '@civicactions/data-catalog-services';
 import PageNotFound from '../PageNotFound';
 import FilteredResourceBody from './FilteredResourceBody';
 
-const FilteredResource = ({id, dist_id, location, apiDocPage, additionalParams, customColumns}) => {
+const FilteredResource = ({id, dist_id, location, apiDocPage, additionalParams, customColumns, setDatasetTitle}) => {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(false);
   const {dataset} = useMetastoreDataset(id, process.env.REACT_APP_ROOT_URL, additionalParams);
@@ -14,6 +14,9 @@ const FilteredResource = ({id, dist_id, location, apiDocPage, additionalParams, 
     }
     if (dataset.distribution && dataset.distribution.length) {
       setReady(true);
+      if(setDatasetTitle) {
+        setDatasetTitle(dataset.title);
+      }
       if (!dataset.distribution[distIndex]) {
         setError(true);
       }

--- a/src/templates/Footer/index.jsx
+++ b/src/templates/Footer/index.jsx
@@ -60,13 +60,33 @@ const Footer = ({
                   <div>
                     <h3 className="ds-h6 dc-footer--heading ds-u-margin-bottom--2">Additional resources</h3>
                     <ul className="ds-u-font-size--small">
-                      {footerAdditionalResourcesLinks.map((link) => (
-                        <li className="ds-u-margin-bottom--1" key={link.id}>
-                          <NavLink 
-                            link={link} 
-                            className="dc-menu-item"/>
-                        </li>
-                      ))}
+                      {footerAdditionalResourcesLinks.filter((link) => {
+                        const noOnClick = Object.keys(link).findIndex((l) => (l === "onClick"));
+                        if(noOnClick === -1 || (link.onClick && link.dataTag)) {
+                          return link;
+                        }
+                      }).map((link) => {
+                        if(link.onClick && link.dataTag) {
+                          return(
+                            <li className="ds-u-margin-bottom--1" key={link.id}>
+                              <a 
+                                href={link.url}
+                                {...{['data-' + link.dataTag.name]: link.dataTag.value}}
+                                onClick={link.onClick}
+                              >
+                                {link.label}
+                              </a>
+                            </li>
+                          )
+                        }
+                        return(
+                          <li className="ds-u-margin-bottom--1" key={link.id}>
+                            <NavLink 
+                              link={link} 
+                              className="dc-menu-item"/>
+                          </li>
+                        )
+                      })}
                     </ul>
                   </div>
                 </div>


### PR DESCRIPTION
This PR contains updates to work with tealium. For the dataset and filtered resource pages, the components now accept a new prop that will set the set the page title to the title from the metadata once retrieved. 

In the footer menu, the additional menu items have been updated to look for an onClick function and if it exists load a different menu link for the privacy settings feature. 