### PR TITLE
Reduce Z-Index on resize handle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.6.1-alpha.1",
+  "version": "1.6.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.6.0",
+  "version": "1.6.1-alpha.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/styles/scss/templates/dataset.scss
+++ b/src/styles/scss/templates/dataset.scss
@@ -23,7 +23,7 @@
   min-width: 10px;
   display: block;
   margin-left: -10px;
-  z-index: 1000;
+  z-index: 1;
   &.isResizing,
   &:hover {
     background-color: $color-primary-darker;


### PR DESCRIPTION
The z-index was too high! Lowered it to 1 from 1000 so it would sit above the sort feature on the tables but not float above the drawer feature from CMS Design System. 