### PR TITLE
Allow for custom updates to Resource Table and Filtered Resource titles

### DIFF
--- a/src/components/ResourcePreview/index.jsx
+++ b/src/components/ResourcePreview/index.jsx
@@ -41,6 +41,7 @@ const ResourcePreview = ({
   truncateCellHeader,
   columnSettings,
   columnWidths,
+  customClasses,
 }) => {
   const previewContainer = React.useRef(null);
   const columnDefaults = {
@@ -71,6 +72,7 @@ const ResourcePreview = ({
     columnIsSortedDecClassName: 'dc-c-sort dc-c-sort--desc',
     tableColumnResizer: 'dc-c-resize-handle',
     tableColumnIsResizing: 'isResizing',
+    ...customClasses,
   };
   return (
     <div

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -20,6 +20,7 @@ const FilteredResourceBody = ({
   customColumns,
   columnSettings,
   columnWidths,
+  customTitle,
 }) => {
   const [tablePadding, setTablePadding] = React.useState('ds-u-padding-y--1');
   let apiDocs = useRef();
@@ -58,6 +59,7 @@ const FilteredResourceBody = ({
     { encode: true }
   )}&format=csv`;
   const pageTitle = distribution.data.title ? distribution.data.title : dataset.title;
+
   return (
     <section className="ds-l-container ds-u-padding-bottom--3 ds-u-margin-bottom--2">
       {Object.keys(distribution).length && (
@@ -65,7 +67,7 @@ const FilteredResourceBody = ({
           <Link to={`/dataset/${id}`} className="ds-u-padding-y--3 ds-u-display--block">
             Back to {dataset.title}
           </Link>
-          <h1 className="ds-title">{pageTitle}</h1>
+          <h1 className="ds-title">{customTitle ? customTitle : pageTitle}</h1>
           <p
             className="ds-u-margin-top--0"
             dangerouslySetInnerHTML={{ __html: distribution.data.description }}

--- a/src/templates/FilteredResource/functions.js
+++ b/src/templates/FilteredResource/functions.js
@@ -1,8 +1,13 @@
 export function buildCustomColHeaders(customHeaders, columns, schema) {
   return columns.map((column) => {
-    const customHeaderIndex = customHeaders.findIndex((header) => header.id === column);
+    const customHeaderIndex = customHeaders.findIndex((header) => header.accessor === column);
     if (customHeaderIndex > -1) {
-      return customHeaders[customHeaderIndex];
+      return {
+        Header:
+          schema && schema.fields[column].description ? schema.fields[column].description : column,
+        accessor: column,
+        ...customHeaders[customHeaderIndex],
+      };
     }
     return {
       Header:

--- a/src/templates/FilteredResource/index.jsx
+++ b/src/templates/FilteredResource/index.jsx
@@ -13,6 +13,7 @@ const FilteredResource = ({
   setDatasetTitle,
   columnSettings,
   columnWidths,
+  customTitle,
 }) => {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(false);
@@ -67,6 +68,7 @@ const FilteredResource = ({
               customColumns={customColumns ? customColumns : []}
               columnSettings={columnSettings}
               columnWidths={columnWidths}
+              customTitle={customTitle}
             />
           )}
         </>


### PR DESCRIPTION
This PR adds some customization options to the Dataset and Filtered Resource sections of the catalog. 

1. You can now override table classes in ResourcePreview with the customCustom classes prop.
2. A custom page title can be passed to the FilteredResource page
3. The custom columns function will now add the header and accessor using scheme description but these can be overwritten by passing a custom title. You can still pass in Cell prop to customize the table cell output.