### PR TITLE
Add better no results messaging to search

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.9.0-alpha.4",
+  "version": "1.9.0-alpha.5",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.9.0-alpha.5",
+  "version": "1.9.0-alpha.6",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.9.0-alpha.6",
+  "version": "1.9.0-alpha.7",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/DatasetSearchFacets/index.jsx
+++ b/src/components/DatasetSearchFacets/index.jsx
@@ -22,7 +22,7 @@ const DatasetSearchFacets = ({ title, facets, onclickFunction, selectedFacets, l
     <div className="ds-u-margin-bottom--4 dc-dataset-search--facets-container">
       <Accordion>
         <AccordionItem heading={`${title} (${filteredFacets.length})`} defaultOpen>
-          <div>
+          <>
             {filteredFacets.length ? (
               <ul className="dc-dataset-search--facets ds-u-padding--0 ds-u-margin--0">
                 {filteredFacets.map((f) => {
@@ -43,7 +43,7 @@ const DatasetSearchFacets = ({ title, facets, onclickFunction, selectedFacets, l
             ) : (
               <p className="ds-h5">No matching facets found.</p>
             )}
-          </div>
+          </>
         </AccordionItem>
       </Accordion>
     </div>

--- a/src/components/DatasetSearchFacets/index.jsx
+++ b/src/components/DatasetSearchFacets/index.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Choice, Button } from '@cmsgov/design-system';
+import { Choice, Button, Accordion, AccordionItem } from '@cmsgov/design-system';
 
 export function isSelected(currentFacet, selectedFacets) {
   let isSelected = -1;
@@ -10,65 +10,48 @@ export function isSelected(currentFacet, selectedFacets) {
   return isSelected;
 }
 
-const DatasetSearchFacets = ({ title, facets, onclickFunction, selectedFacets }) => {
+const DatasetSearchFacets = ({ title, facets, onclickFunction, selectedFacets, loading }) => {
   const showLimit = 25;
   const [isOpen, setIsOpen] = useState(true);
   const [showMore, setShowMore] = useState(false);
-  const filteredFacets = facets.filter((f) => f.total > 0);
+  const filteredFacets = facets.filter((f) => {
+    const selectedIndex = selectedFacets.findIndex((item) => item === f.name);
+    return f.total > 0 || selectedIndex !== -1;
+  });
   return (
-    <div className="ds-u-margin-bottom--4">
-      <Button
-        variation="transparent"
-        className={`dc-facet-block--toggle ds-h4 ds-u-margin-top--0 ds-u-padding-left--0 ${
-          isOpen ? 'open' : 'closed'
-        }`}
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        {title}
-      </Button>
-      {isOpen && (
-        <div>
-          <ul className="dc-dataset-search--facets ds-u-padding--0 ds-u-margin--0">
-            {filteredFacets
-              .filter((facet, index) => {
-                if (!showMore) {
-                  if (index <= showLimit) {
-                    return facet;
-                  } else {
-                    return false;
-                  }
-                }
-                return facet;
-              })
-              .map((f) => {
-                return (
-                  <li key={f.name}>
-                    <Choice
-                      checked={isSelected(f.name, selectedFacets) > -1 ? true : false}
-                      name={`facet_theme_${f.name}`}
-                      type="checkbox"
-                      label={`${f.name} (${f.total})`}
-                      value={f.name}
-                      onClick={(e) => onclickFunction({ key: f.type, value: e.target.value })}
-                    />
-                  </li>
-                );
-              })}
-          </ul>
-          {!showMore && filteredFacets.length > showLimit && (
-            <Button variation="transparent" onClick={() => setShowMore(true)}>
-              Show more
-            </Button>
-          )}
-          {showMore && filteredFacets.length > showLimit && (
-            <Button variation="transparent" onClick={() => setShowMore(false)}>
-              Show less
-            </Button>
-          )}
-        </div>
-      )}
+    <div className="ds-u-margin-bottom--4 dc-dataset-search--facets-container">
+      <Accordion>
+        <AccordionItem heading={`${title} (${filteredFacets.length})`} defaultOpen>
+          <div>
+            {filteredFacets.length ? (
+              <ul className="dc-dataset-search--facets ds-u-padding--0 ds-u-margin--0">
+                {filteredFacets.map((f) => {
+                  return (
+                    <li key={f.name}>
+                      <Choice
+                        checked={isSelected(f.name, selectedFacets) > -1 ? true : false}
+                        name={`facet_theme_${f.name}`}
+                        type="checkbox"
+                        label={`${f.name} (${f.total})`}
+                        value={f.name}
+                        onClick={(e) => onclickFunction({ key: f.type, value: e.target.value })}
+                      />
+                    </li>
+                  );
+                })}
+              </ul>
+            ) : (
+              <p className="ds-h5">No matching facets found.</p>
+            )}
+          </div>
+        </AccordionItem>
+      </Accordion>
     </div>
   );
+};
+
+DatasetSearchFacets.defaultProps = {
+  selectedFacets: [],
 };
 
 DatasetSearchFacets.propTypes = {

--- a/src/components/DatasetSearchFacets/index.jsx
+++ b/src/components/DatasetSearchFacets/index.jsx
@@ -21,7 +21,11 @@ const DatasetSearchFacets = ({ title, facets, onclickFunction, selectedFacets, l
   return (
     <div className="ds-u-margin-bottom--4 dc-dataset-search--facets-container">
       <Accordion>
-        <AccordionItem heading={`${title} (${filteredFacets.length})`} defaultOpen>
+        <AccordionItem
+          contentClassName="ds-u-padding-left--1 ds-u-padding-right--0"
+          heading={`${title} (${filteredFacets.length})`}
+          defaultOpen
+        >
           <>
             {filteredFacets.length ? (
               <ul className="dc-dataset-search--facets ds-u-padding--0 ds-u-margin--0">

--- a/src/styles/scss/components/dataset-search-facets.scss
+++ b/src/styles/scss/components/dataset-search-facets.scss
@@ -1,6 +1,5 @@
 .dc-dataset-search--facets-container .ds-c-accordion__content {
   max-height: 32rem;
-  display: block;
 }
 
 .dc-dataset-search--facets {

--- a/src/styles/scss/components/dataset-search-facets.scss
+++ b/src/styles/scss/components/dataset-search-facets.scss
@@ -1,3 +1,7 @@
+.dc-dataset-search--facets-container .ds-c-accordion__content {
+  max-height: 32rem;
+}
+
 .dc-dataset-search--facets {
   list-style: none;
 }

--- a/src/styles/scss/components/dataset-search-facets.scss
+++ b/src/styles/scss/components/dataset-search-facets.scss
@@ -8,5 +8,4 @@
   list-style: none;
   position: relative;
   max-height: 32rem;
-  overflow: scroll;
 }

--- a/src/styles/scss/components/dataset-search-facets.scss
+++ b/src/styles/scss/components/dataset-search-facets.scss
@@ -1,7 +1,12 @@
 .dc-dataset-search--facets-container .ds-c-accordion__content {
   max-height: 32rem;
+  display: block;
 }
 
 .dc-dataset-search--facets {
+  display: block;
   list-style: none;
+  position: relative;
+  max-height: 32rem;
+  overflow: scroll;
 }

--- a/src/templates/DatasetSearch/index.jsx
+++ b/src/templates/DatasetSearch/index.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import qs from 'qs';
 import { useSearchAPI, separateFacets } from '@civicactions/data-catalog-services';
-import { TextField, Dropdown, Spinner, Button } from '@cmsgov/design-system';
+import { TextField, Dropdown, Spinner, Button, Alert } from '@cmsgov/design-system';
 import DatasetSearchListItem from '../../components/DatasetSearchListItem';
 import Pagination from '../../components/Pagination';
 import DatasetSearchFacets from '../../components/DatasetSearchFacets';
@@ -57,6 +57,7 @@ const DatasetSearch = ({
   showSort,
 }) => {
   const [currentResultNumbers, setCurrentResultNumbers] = useState(null);
+  const [noResults, setNoResults] = useState(false);
   const {
     fulltext,
     selectedFacets,
@@ -102,13 +103,17 @@ const DatasetSearch = ({
       startingNumber: startingNumber,
       endingNumber: Number(totalItems) < endingNumber ? Number(totalItems) : endingNumber,
     });
+    if (totalItems <= 0 && currentResultNumbers !== null) {
+      setNoResults(true);
+    } else {
+      setNoResults(false);
+    }
   }, [totalItems, pageSize, page]);
 
   function changePage(page) {
     setPage(page);
     window.scroll(0, 0);
   }
-
   return (
     <section className="ds-l-container">
       <h1 className="dc-search-header ds-title ds-u-margin-y--3">{pageTitle}</h1>
@@ -166,6 +171,7 @@ const DatasetSearch = ({
             </Button>
           </div>
           <ol className="dc-dataset-search-list ds-u-padding--0">
+            {noResults && <Alert variation="error" heading="No results found." />}
             {items.map((item) => (
               <li className="ds-u-padding--0">
                 <DatasetSearchListItem item={item} updateFacets={updateSelectedFacets} />
@@ -211,6 +217,7 @@ const DatasetSearch = ({
                 facets={theme}
                 onclickFunction={updateSelectedFacets}
                 selectedFacets={selectedFacets.theme}
+                loading={loading}
               />
             ) : (
               <Spinner
@@ -225,6 +232,7 @@ const DatasetSearch = ({
                 facets={keyword}
                 onclickFunction={updateSelectedFacets}
                 selectedFacets={selectedFacets.keyword}
+                loading={loading}
               />
             ) : (
               <Spinner


### PR DESCRIPTION
This PR addresses a couple of issues in the dataset explorer page and swaps out some components for upstream ones. 

- Adds an alert to the main section of the site when no results are found. 
- Updates the facets to display any facets selected, even if they have 0 results. This fixes an edge case where you could click two facets quickly that would return 0 results and 0 facets and the only option to fix the page was the clear all filters button
- Changes the facets container to the CMS Design System accordion which has native open and close feature with accessible focus traps and a built in scrollbar for overflow. Adding this allowed for removal of the show more button and we can now list all the facets without making the page grow too big. 
- Added the number of facets currently available next to the Keyword or Category title. 
