### PR TITLE
Add break-word to dataset download link

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/DatasetDownloads/index.jsx
+++ b/src/components/DatasetDownloads/index.jsx
@@ -8,7 +8,9 @@ const DatasetDownloads = ({ downloadURL, type }) => {
         Downloads
       </h2>
       <p className="ds-u-margin-bottom--1 ds-u-color--gray">Resource</p>
-      <a href={downloadURL}>Download this resource ({type})</a>
+      <a href={downloadURL} className="ds-u-word-break">
+        Download this resource ({type})
+      </a>
     </div>
   );
 };


### PR DESCRIPTION
Most files have a 3 letter code like zip/or csv for the download link so this PR fixes some edge cases. 

On a page like: https://data.healthcare.gov/dataset/32ei-4grr, the type prop is set to something long without any break points for the browser to use so this PR adds the css class break-word to just add breaks when needed to fit the container. 