### PR TITLE
Fix new flex styles on accordion titles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.12.0",
+  "version": "1.12.1-alpha.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "1.12.0",
+      "version": "1.12.1-alpha.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/data-catalog-components": "2.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.12.0",
+  "version": "1.12.1-alpha.3",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/components/ResourceHeader/index.jsx
+++ b/src/components/ResourceHeader/index.jsx
@@ -55,7 +55,7 @@ const ResourceHeader = ({
           <div className="ds-u-font-weight--bold">
             <DataTablePageResults totalRows={intCount} limit={limit} offset={offset} />
           </div>
-          <div>
+          <div className="dc-c-resource-header--buttons">
             {includeDownload && (
               <>
                 <Button

--- a/src/styles/scss/templates/dataset-search.scss
+++ b/src/styles/scss/templates/dataset-search.scss
@@ -30,3 +30,9 @@
 .dataset-results-count {
   font-weight: bold;
 }
+
+.dc-dataset-search--facets-container .ds-c-accordion__button {
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 24px 16px 24px;
+}

--- a/src/styles/scss/templates/filtered-resource.scss
+++ b/src/styles/scss/templates/filtered-resource.scss
@@ -13,3 +13,7 @@
     }
   }
 }
+
+.dc-c-resource-header--buttons {
+  display: flex;
+}

--- a/src/styles/scss/templates/header.scss
+++ b/src/styles/scss/templates/header.scss
@@ -1,5 +1,14 @@
 @import '~@cmsgov/design-system/dist/scss/settings/variables/color';
 
+.ds-c-usa-banner__button-text {
+  &::after {
+    width: 0 !important;
+    height: 0 !important;
+    margin: 0 !important;
+    padding: 0 !important;
+  }
+}
+
 .dc-c-mobile-menu--open {
   color: $color-white;
   text-decoration: none;

--- a/src/styles/scss/templates/query-builder.scss
+++ b/src/styles/scss/templates/query-builder.scss
@@ -13,3 +13,10 @@
   bottom: 0;
   background-color: white;
 }
+
+.dc-query-builder .ds-c-accordion__heading > .ds-c-accordion__button {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  padding: 16px 24px 16px 24px;
+}

--- a/src/templates/FilteredResource/QueryTitle.jsx
+++ b/src/templates/FilteredResource/QueryTitle.jsx
@@ -32,7 +32,7 @@ const QueryTitle = ({ conditions, schema, customColumns }) => {
   }
 
   return (
-    <>
+    <span className="dc-querybuilder-title">
       {conditions
         .map((c) => {
           const field = fields[c.property];
@@ -55,7 +55,7 @@ const QueryTitle = ({ conditions, schema, customColumns }) => {
           </Badge>,
           curr,
         ])}
-    </>
+    </span>
   );
 };
 


### PR DESCRIPTION
Wraps the QueryBuilder filters in a div. This fixes an issue with layout when more than one filter is present, as the new button uses flex box and it was adding space between to all the filters. 

Adds some extra styling to address issues on Data.Healthcare which currently doesn't have the newest Design System loaded at the Drupal theme level. 