### PR TITLE
Set min width and remove flex on swagger info at mobile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/data-catalog-components": "2.0.0-beta.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {

--- a/src/styles/scss/templates/swagger.scss
+++ b/src/styles/scss/templates/swagger.scss
@@ -11,7 +11,7 @@
 }
 
 .swagger-ui .opblock-tag-section {
-  min-width: 300px;
+  min-width: 460px;
 }
 
 @media (max-width: 544px) {

--- a/src/styles/scss/templates/swagger.scss
+++ b/src/styles/scss/templates/swagger.scss
@@ -9,3 +9,13 @@
     min-width: 80px !important;
   }
 }
+
+.swagger-ui .opblock-tag-section {
+  min-width: 300px;
+}
+
+@media (max-width: 544px) {
+  .swagger-ui .opblock-tag small {
+    flex: initial;
+  }
+}


### PR DESCRIPTION
If you shrink your browser down the text in the swagger component will shrink until it is one character per line. 