### PR TITLE
Add whitespace: preline to metadata descriptions

### DIFF
--- a/src/styles/scss/templates/dataset.scss
+++ b/src/styles/scss/templates/dataset.scss
@@ -31,3 +31,7 @@
     background-color: $color-primary;
   }
 }
+
+.dc-c-metadata-description {
+  white-space: pre-line;
+}

--- a/src/templates/Dataset/DatasetBody.jsx
+++ b/src/templates/Dataset/DatasetBody.jsx
@@ -74,7 +74,7 @@ const DatasetBody = ({
               </p>
             )}
           </div>
-          <p dangerouslySetInnerHTML={{ __html: dataset.description }} />
+          <p className="dc-c-metadata-description" dangerouslySetInnerHTML={{ __html: dataset.description }} />
           {resource.columns && Object.keys(resource.schema).length ? (
             <>
               <h2 className="dc-resource-header">Resource Preview</h2>

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -83,7 +83,7 @@ const FilteredResourceBody = ({
           </Link>
           <h1 className="ds-title">{customTitle ? customTitle : pageTitle}</h1>
           <p
-            className="ds-u-margin-top--0"
+            className="ds-u-margin-top--0 dc-c-metadata-description"
             dangerouslySetInnerHTML={{ __html: distribution.data.description }}
           />
           {resource.columns && Object.keys(resource.schema).length && (


### PR DESCRIPTION
This class/style will process any `\n` that comes from the dataset description in the api.