### PR TITLE
Fix search double back

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.15.1",
+  "version": "1.15.2-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "1.15.1",
+      "version": "1.15.2-alpha.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/data-catalog-components": "~2.1.0",
@@ -52,6 +52,7 @@
         "@testing-library/jest-dom": "^5.9.0",
         "@testing-library/react": "^10.2.1",
         "@testing-library/react-hooks": "^3.3.0",
+        "@testing-library/user-event": "^14.4.3",
         "babel-eslint": "^10.0.3",
         "babel-jest": "^26.6.0",
         "babel-loader": "8.1.0",
@@ -3907,6 +3908,19 @@
       "peerDependencies": {
         "react": ">=16.9.0",
         "react-test-renderer": ">=16.9.0"
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {
@@ -29344,6 +29358,13 @@
         "@babel/runtime": "^7.12.5",
         "@types/testing-library__react-hooks": "^3.4.0"
       }
+    },
+    "@testing-library/user-event": {
+      "version": "14.4.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.4.3.tgz",
+      "integrity": "sha512-kCUc5MEwaEMakkO5x7aoD+DLi02ehmEM2QCGWvNqAS1dV/fAvORWEjnjsEIvml59M7Y5kCkWN6fCCyPOe8OL6Q==",
+      "dev": true,
+      "requires": {}
     },
     "@tootallnate/once": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "1.15.1",
+  "version": "1.15.2-alpha.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "lib/index.js",
   "scripts": {
@@ -58,6 +58,7 @@
     "@testing-library/jest-dom": "^5.9.0",
     "@testing-library/react": "^10.2.1",
     "@testing-library/react-hooks": "^3.3.0",
+    "@testing-library/user-event": "^14.4.3",
     "babel-eslint": "^10.0.3",
     "babel-jest": "^26.6.0",
     "babel-loader": "8.1.0",

--- a/src/templates/DatasetSearch/index.jsx
+++ b/src/templates/DatasetSearch/index.jsx
@@ -6,17 +6,6 @@ import { TextField, Dropdown, Spinner, Button, Alert, Pagination } from '@cmsgov
 import DatasetSearchListItem from '../../components/DatasetSearchListItem';
 import DatasetSearchFacets from '../../components/DatasetSearchFacets';
 
-// function updateUrl(selectedFacets, fulltext, sort) {
-//   let newParams = { ...selectedFacets };
-//   if (fulltext) {
-//     newParams.fulltext = fulltext;
-//   }
-//   if (sort) {
-//     newParams.sort = sort;
-//   }
-//   return qs.stringify(newParams, { addQueryPrefix: true, encode: false });
-// }
-
 export function selectedFacetsMessage(facets, alternateTitles) {
   let message = [];
   const keys = Object.keys(facets);
@@ -116,7 +105,10 @@ const DatasetSearch = ({
   }, [fulltext]);
 
   useEffect(() => {
-    setSearchParams(buildSearchParams(true));
+    var params = buildSearchParams(true);
+    if (params !== location.search) {
+      setSearchParams(params);
+    }
   }, [page, sort, sortOrder, fulltext, selectedFacets]);
 
   useEffect(() => {


### PR DESCRIPTION
Currently when the search page loads, it runs the useEffect on page load which updates the browser history adding two instances to the browser. This update just checks to make sure the params in state do not match the `location.search` before firing so you don't get duplicate entries. 

Ticket number 10689