### PR TITLE
Persist underline for current page in header

### DIFF
--- a/src/components/NavLink/NavLink.scss
+++ b/src/components/NavLink/NavLink.scss
@@ -1,0 +1,3 @@
+nav.dc-c-site-menu .dc-c-header--links a.dc-c-active-link span {
+  border-bottom: 2px solid #{var(--color-primary-alt-light)};
+}

--- a/src/components/NavLink/index.jsx
+++ b/src/components/NavLink/index.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { NavLink as RRDNavLink } from 'react-router-dom';
+import './NavLink.scss';
 // import validator from 'validator';
 
 const NavLink = ({ link, className, wrapLabel }) => {

--- a/src/templates/Header/header.scss
+++ b/src/templates/Header/header.scss
@@ -315,7 +315,7 @@ nav.dc-c-site-menu {
     > li:focus > a span,
     > li a:hover span,
     > li a:focus span {
-      border-bottom: 2px solid #{var(--color-primary-alt-light)};
+      border-bottom: 2px solid #{var(--color-primary-alt-lightest)};
     }
   }
 }


### PR DESCRIPTION
Note: Overrides on some downstreams mean this does not display in all apps.
Currently working on:
data.medicaid.gov
pfs-data
data.healthcare.gov
