### PR TITLE
Update search modal styles and markup

### DIFF
--- a/src/components/SearchModal/index.jsx
+++ b/src/components/SearchModal/index.jsx
@@ -6,6 +6,7 @@ import { Button, Dialog, TextField } from '@cmsgov/design-system';
 const SearchModal = ({
   searchFunc,
   appNodeId,
+  headingText,
   searchModalText,
   buttonSize,
   inversedModalButton,
@@ -44,10 +45,12 @@ const SearchModal = ({
           className="dc-c-search-dialog"
           onExit={() => setModalSearch(false)}
           getApplicationNode={() => document.getElementById(appNodeId)}
-          closeButtonVariation="primary"
           closeButtonText={<>Close</>}
+          heading={`${headingText}`}
         >
-          <p>{searchModalText}</p>
+          {searchModalText &&
+            <p>{searchModalText}</p>
+          }
           <form
             className="ds-u-display--flex ds-u-align-items--stretch ds-u-flex-wrap--nowrap"
             onSubmit={(e) => {
@@ -63,7 +66,7 @@ const SearchModal = ({
               labelClassName="ds-u-visibility--screen-reader"
               onChange={(e) => setModalSearchTerm(e.target.value)}
             />
-            <Button type="submit" onDark={inversedModalButton} className="ds-l-col--3">
+            <Button type="submit" className="ds-l-col--3">
               <span className="fas fa-search small-text ds-u-sm-display--none" />
               <span className="full-text ds-u-display--none ds-u-sm-display--inline-block">
                 Search
@@ -81,6 +84,7 @@ SearchModal.defaultProps = {
   buttonSize: null,
   inversedModalButton: true,
   inversedSearchButton: true,
+  headingText: "Dataset Search"
 };
 
 export default SearchModal;

--- a/src/styles/scss/index.scss
+++ b/src/styles/scss/index.scss
@@ -12,13 +12,3 @@ main {
 html a:focus {
   background-color: transparent;
 }
-
-button.ds-c-dialog__close {
-  &:focus {
-    background-color: transparent;
-    outline: 3px solid #bd13b8;
-    box-shadow: none;
-    outline-offset: inherit;
-    border-radius: 0px;
-  }
-}

--- a/src/templates/Header/header.scss
+++ b/src/templates/Header/header.scss
@@ -255,17 +255,17 @@
 //   background-image: linear-gradient(90deg, $color-primary-darkest 10%,$color-primary 90%);
 // }
 
-header.dc-c-header .dc-c-main-navigation--search {
-  button {
-    &:focus {
-      background-color: transparent;
-      outline: 3px solid #bd13b8;
-      box-shadow: none;
-      outline-offset: inherit;
-      border-radius: 0px;
-    }
-  }
-}
+// header.dc-c-header .dc-c-main-navigation--search {
+//   button {
+//     &:focus {
+//       background-color: transparent;
+//       outline: 3px solid #bd13b8;
+//       box-shadow: none;
+//       outline-offset: inherit;
+//       border-radius: 0px;
+//     }
+//   }
+// }
 
 nav.dc-c-site-menu {
   .dc-c-header--links {
@@ -299,15 +299,15 @@ nav.dc-c-site-menu {
         border-radius: #{var(--button__border-radius)};
       }
     }
-    button {
-      &:focus {
-        // background-color: transparent;
-        // outline: 3px solid #bd13b8;
-        // box-shadow: none;
-        // outline-offset: inherit;
-        // border-radius: 0px;
-      }
-    }
+    // button {
+    //   &:focus {
+    //     // background-color: transparent;
+    //     // outline: 3px solid #bd13b8;
+    //     // box-shadow: none;
+    //     // outline-offset: inherit;
+    //     // border-radius: 0px;
+    //   }
+    // }
     > li:hover > button span,
     > li button:focus span,
     > li button:hover span,
@@ -364,28 +364,28 @@ li.has-submenu {
 //   color: #{var(--color-white)};
 // }
 
-div.ds-c-dialog-wrap {
-  background-color: rgba(0, 113, 188, 0.9);
-}
+// div.ds-c-dialog-wrap {
+//   background-color: rgba(0, 113, 188, 0.9);
+// }
 
-div.ds-c-dialog {
-  background-color: transparent;
-  box-shadow: none;
-  color: #{var(--color-white)};
-  width: 100%;
-  height: 100%;
-}
+// div.ds-c-dialog {
+//   background-color: transparent;
+//   box-shadow: none;
+//   color: #{var(--color-white)};
+//   width: 100%;
+//   height: 100%;
+// }
 
-div.ds-c-dialog button {
-  background-color: transparent;
-}
-.ds-c-dialog__header .ds-c-dialog__close {
-  color: #{var(--color-white)};
-  background: none;
-  position: absolute;
-  top: 24px;
-  right: 24px;
-}
+// div.ds-c-dialog button {
+//   background-color: transparent;
+// }
+// .ds-c-dialog__header .ds-c-dialog__close {
+//   color: #{var(--color-white)};
+//   background: none;
+//   position: absolute;
+//   top: 24px;
+//   right: 24px;
+// }
 
 .dc-c-mobile-menu--search {
   display: inherit;


### PR DESCRIPTION
I will probably have an update when I move this to data.healthcare but I wanted to start from a more base CMS Design System setup since it had the light gray header. I may just try to fix the styles downstream on that one. I added a heading to it since the new look isn't a full screen background with just the input but a more traditional modal looking element.

If you can check against PFS the same setup should then work for QIC and Data.Medicaid. Open Payments removed this feature and Data.Healthcare may remove it in a future round of design updates.  