### PR TITLE
WCMS-14339: Announce Data Search results to screen readers

### DIFF
--- a/src/templates/DatasetSearch/DatasetSearch.jsx
+++ b/src/templates/DatasetSearch/DatasetSearch.jsx
@@ -181,7 +181,7 @@ const DatasetSearch = ({
               <div className="ds-u-display--flex ds-u-justify-content--between ds-u-align-items--end">
               <div>
                 {currentResultNumbers && (
-                  <p className="ds-u-margin-y--0">
+                  <p className="ds-u-margin-y--0" role="region" aria-live="polite" data-currentResults="" >
                     Showing {currentResultNumbers.startingNumber} -{' '}
                     {currentResultNumbers.endingNumber} of {data.data.total} datasets
                   </p>

--- a/src/templates/DatasetSearch/datasetsearch.test.jsx
+++ b/src/templates/DatasetSearch/datasetsearch.test.jsx
@@ -55,4 +55,23 @@ describe('<DatasetSearchFacets />', () => {
     expect(screen.getByText(/0-0 out of 0/i));
     expect(screen.getByText('[0 entries total on page]'));
   });
+
+  test('Announces search results to screen readers', async () => {
+    await axios.get.mockImplementation(() => Promise.resolve(data_results));
+    const { debug } = render(<DatasetSearch rootUrl={rootUrl} />);
+    await act(async () => {
+      // debug()
+      jest.useFakeTimers();
+    });
+
+    const dataCurrentResultsElement = screen.getByTestId('data-currentResults');
+
+    expect(dataCurrentResultsElement).toBeInTheDocument();
+    expect(dataCurrentResultsElement).toHaveAttribute('role', 'region');
+    expect(dataCurrentResultsElement).toHaveAttribute('aria-live');
+    expect(['polite', 'assertive']).toContain(dataCurrentResultsElement.getAttribute('aria-live'));
+
+  });
 });
+
+


### PR DESCRIPTION
 WCMS-14339: Adding necessary attributes to allow screen readers to be alerted of the search result outcome