### PR TITLE
Return null instead of 0 when no data dictionary tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0-rc.2",
       "license": "GPL-3.0",
       "dependencies": {
         "@popperjs/core": "^2.11.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -169,7 +169,7 @@ const Dataset = ({
                   >
                     <DatasetOverview resource={resource} dataset={dataset} distributions={distributions} metadataMapping={metadataMapping} />
                   </TabPanel>
-                  { datasetDictionary && datasetDictionary.length && (
+                  { datasetDictionary && datasetDictionary.length ? (
                     <TabPanel
                       id={'data-dictionary'}
                       tab={
@@ -181,7 +181,8 @@ const Dataset = ({
                     >
                       <DataDictionary datasetDictionary={datasetDictionary} title={"Data Dictionary"} />
                     </TabPanel>
-                  )}
+                  )
+                  : null}
                   <TabPanel
                     id={'api'}
                     tab={


### PR DESCRIPTION
When no data dictionary tab exists, a 0 was appearing below the table. Returning `null` instead seems to make it go away. 