### PR TITLE
Fixes aria-hidden on facet accordion to be hidden for improved accessibility

### DIFF
--- a/src/components/DatasetSearchFacets/dataset_search_facets.test.jsx
+++ b/src/components/DatasetSearchFacets/dataset_search_facets.test.jsx
@@ -37,4 +37,16 @@ describe('<DatasetSearchFacets />', () => {
       screen.getByRole('checkbox', { name: 'facet-1 (2)', checked: true })
     ).toBeInTheDocument();
   });
+  test('Accordion svgs are hidden', () => {
+    const handleClick = jest.fn();
+    render(
+      <DatasetSearchFacets title="Facets" facets={testFacets} onClickFunction={handleClick} />
+    );
+    expect(screen.queryByTitle('Close')).toBe(null);
+    expect(screen.queryByRole('img')).toBe(null);
+    fireEvent.click(screen.getByRole('button', { name: 'Facets' }));
+    expect(screen.queryByTitle('Open')).toBe(null);
+    expect(screen.queryByRole('img')).toBe(null);
+  });
+
 });

--- a/src/components/DatasetSearchFacets/index.tsx
+++ b/src/components/DatasetSearchFacets/index.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Choice, Accordion, AccordionItem } from '@cmsgov/design-system';
+import { Choice, Accordion, AccordionItem, AddIcon, RemoveIcon } from '@cmsgov/design-system';
 import { SearchAPIFacetType, SearchFacetsPropTypes } from '../../types/search';
 import './dataset-search-facets.scss';
 
@@ -9,6 +9,9 @@ const SearchFacets = (props: SearchFacetsPropTypes) => {
     return Number(f.total) > 0 || selectedFacets.findIndex((i) => i === f.name) !== -1;
   });
 
+  const hiddenAddIcon = () => <AddIcon ariaHidden={true} />;
+  const hiddenCloseIcon = () => <RemoveIcon ariaHidden={true} />;
+
   return (
     <div className="dkan-dataset-search--facet-container ds-u-margin-bottom--4">
       <Accordion>
@@ -16,6 +19,8 @@ const SearchFacets = (props: SearchFacetsPropTypes) => {
           contentClassName="ds-u-padding-left--1 ds-u-padding-right--0"
           heading={title}
           defaultOpen
+          openIconComponent={hiddenAddIcon}
+          closeIconComponent={hiddenCloseIcon}
         >
           <ul>
             {filteredFacets.length ? filteredFacets


### PR DESCRIPTION
When a screen reader user encounters the Categories and Tags accordions, the button text and SVG title are both read aloud, and they seem to contradict.

For example, when the Categories accordion is open, a screen reader says, "Categories, Close, Expanded button".

The fix, is just passing a custom icon to the accordion component with aria hidden prop set as true. 