### PR TITLE
Export CSV button: aria-label doesn't match visible text

### DIFF
--- a/src/components/DatatableHeader/DatatableHeader.test.jsx
+++ b/src/components/DatatableHeader/DatatableHeader.test.jsx
@@ -14,6 +14,6 @@ describe('<DatatableHeader />', () => {
 
     const el = screen.getByText('Displaying', {exact: false})
     expect(el.textContent).toEqual("Displaying 1 - 25 of 69 results");
-    expect(screen.getByText("Export CSV")).toBeInTheDocument();
+    expect(screen.getByText("Download filtered data (CSV)")).toBeInTheDocument();
   });
 });

--- a/src/components/DatatableHeader/index.tsx
+++ b/src/components/DatatableHeader/index.tsx
@@ -18,7 +18,7 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
           />
         </div>
         <div className="dc-c-resource-header--buttons ds-l-col--12 ds-l-lg-col--8 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-margin-bottom--2 ds-u-md-margin-bottom--0 ds-u-padding-x--0">
-          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-md-margin-right--2 ds-u-sm-margin-bottom--2 ds-u-md-margin-bottom--0">
+          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-sm-margin-bottom--2 ds-u-md-margin-bottom--0">
             <Tooltip
               onOpen={() => {
                 navigator.clipboard.writeText(window.location.href);
@@ -34,7 +34,7 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
               </span>
             </Tooltip>
           </div>
-          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0">
+          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-sm-margin-left--2">
             <Button
               className="ds-u-text-align--center ds-u-font-weight--normal ds-u-font-size--base ds-u-margin-right--1 ds-u-display--inline-block ds-l-col--12"
               href={downloadURL}

--- a/src/components/DatatableHeader/index.tsx
+++ b/src/components/DatatableHeader/index.tsx
@@ -18,7 +18,7 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
           />
         </div>
         <div className="dc-c-resource-header--buttons ds-l-col--12 ds-l-lg-col--8 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-margin-bottom--2 ds-u-md-margin-bottom--0 ds-u-padding-x--0">
-          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-sm-margin-right--2 ds-u-margin-bottom--2 ds-u-sm-margin-bottom--0">
+          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-md-margin-right--2 ds-u-sm-margin-bottom--2 ds-u-md-margin-bottom--0">
             <Tooltip
               onOpen={() => {
                 navigator.clipboard.writeText(window.location.href);

--- a/src/components/DatatableHeader/index.tsx
+++ b/src/components/DatatableHeader/index.tsx
@@ -10,14 +10,14 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
   return (
     <div className="ds-l-row ds-u-align-items--center ds-u-margin-bottom--2">
       <div className="ds-l-col--12 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--between ds-u-align-items--center">
-        <div className="ds-l-col--12 ds-l-lg-col--6">
+        <div className="ds-l-col--12 ds-l-lg-col--4">
           <DataTablePageResults
             totalRows={intCount}
             limit={limit}
             offset={offset}
           />
         </div>
-        <div className="dc-c-resource-header--buttons ds-l-col--12 ds-l-lg-col--6 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-margin-bottom--2 ds-u-md-margin-bottom--0 ds-u-padding-x--0">
+        <div className="dc-c-resource-header--buttons ds-l-col--12 ds-l-lg-col--8 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-margin-bottom--2 ds-u-md-margin-bottom--0 ds-u-padding-x--0">
           <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-sm-margin-right--2 ds-u-margin-bottom--2 ds-u-sm-margin-bottom--0">
             <Tooltip
               onOpen={() => {
@@ -38,10 +38,9 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
             <Button
               className="ds-u-text-align--center ds-u-font-weight--normal ds-u-font-size--base ds-u-margin-right--1 ds-u-display--inline-block ds-l-col--12"
               href={downloadURL}
-              aria-label="Download filtered data (CSV)"
             >
               <span className="ds-u-font-weight--semibold ds-u-margin-left--1 ds-u-padding--0">
-                <i className="fas fa-file-csv"></i> Export CSV
+                <i className="fas fa-file-csv"></i> Download filtered data (CSV)
               </span>
             </Button>
           </div>

--- a/src/components/DatatableHeader/index.tsx
+++ b/src/components/DatatableHeader/index.tsx
@@ -18,7 +18,7 @@ const DataTableHeader = ({ resource, downloadURL, jsonUrl } : {resource: Resourc
           />
         </div>
         <div className="dc-c-resource-header--buttons ds-l-col--12 ds-l-lg-col--8 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-margin-bottom--2 ds-u-md-margin-bottom--0 ds-u-padding-x--0">
-          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-sm-margin-bottom--2 ds-u-md-margin-bottom--0">
+          <div className="ds-l-col--12 ds-l-sm-col--auto ds-u-padding-x--0 ds-u-margin-bottom--2 ds-u-md-margin-bottom--0">
             <Tooltip
               onOpen={() => {
                 navigator.clipboard.writeText(window.location.href);

--- a/src/components/ResourceHeader/index.jsx
+++ b/src/components/ResourceHeader/index.jsx
@@ -67,7 +67,6 @@ const ResourceHeader = ({
                   size="small"
                   className="ds-u-text-align--left ds-u-font-weight--normal ds-u-font-size--base ds-u-margin-right--1"
                   href={downloadUrl}
-                  aria-label="Download filtered data (CSV)"
                 >
                   <DownloadIcon />
                   {!md && (


### PR DESCRIPTION
The aria-label attribute must contain the full button text exactly as written. When an interactive element has a valid aria-label, assistive tech like screen readers and voice control software will identify the button _only_ by the aria-label and they'll ignore all other text, including the visible text label. [https://www.w3.org/WAI/WCAG22/Understanding/label-in-name.html]

In this case we should remove the aria-label completely and edit the button text to "Download filtered data (CSV)", which is the more descriptive of the two options:

```
<a href="..." aria-label="Download filtered data (CSV)" class="..."><span class="..."><i class="fas fa-file-csv"></i> Export CSV</span></a>
```