### PR TITLE
WCMS-19787 added modified date information to /data page

### DIFF
--- a/src/services/useMetastoreDataset/useMetastoreDataset.tsx
+++ b/src/services/useMetastoreDataset/useMetastoreDataset.tsx
@@ -10,6 +10,7 @@ const useMetastoreDataset = (datasetId : string, rootAPIUrl : string, additional
     error: '',
     description: '',
     identifier: '',
+    modified: '',
   } as DatasetType);
   const [id, setId] = useState(datasetId)
   const [rootUrl, setRootUrl] = useState(rootAPIUrl)
@@ -18,7 +19,7 @@ const useMetastoreDataset = (datasetId : string, rootAPIUrl : string, additional
     async function fetchData() {
       return axios.get(`${rootUrl}/metastore/schemas/dataset/items/${id}?show-reference-ids${additionalParamsString}`)
         .then((res) => setDataset(res.data))
-        .catch((error) => setDataset({title: dataset.title, distribution: dataset.distribution, error: error, description: dataset.description, identifier: dataset.identifier}));
+        .catch((error) => setDataset({title: dataset.title, distribution: dataset.distribution, error: error, description: dataset.description, identifier: dataset.identifier, modified: dataset.modified}));
     }
     fetchData();
   }, [id, rootUrl]);

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -15,6 +15,7 @@ import DatasetOverview from '../../components/DatasetOverviewTab';
 import DatasetAPI from '../../components/DatasetAPITab';
 import DataDictionary from '../../components/DatasetDataDictionaryTab';
 import { DatasetDictionaryItemType, DatasetPageType, DatasetDictionaryType, DistributionType, ResourceType } from '../../types/dataset';
+import TransformedDate from '../../components/TransformedDate';
 import './dataset.scss';
 
 const getSiteWideDataDictionary = (rootUrl : string, dataDictionaryUrl : string) => {
@@ -43,7 +44,7 @@ const Dataset = ({
   apiPageUrl = "/api",
   dataDictionaryUrl,
   borderlessTabs = false,
-  defaultPageSize = 25
+  defaultPageSize = 25,
 } : DatasetPageType) => {
   const options = location.search
     ? { ...qs.parse(location.search, { ignoreQueryPrefix: true }) }
@@ -135,6 +136,11 @@ const Dataset = ({
           <div className={'ds-l-row'}>
             <div className={'ds-l-md-col--9'}>
               <h1 className={'ds-u-margin-bottom--4 ds-h1 title-underline'}>{title}</h1>
+            </div>
+            <div className={'ds-l-md-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right'}>
+              <p>Updated <TransformedDate date={dataset.modified} /></p>
+            </div>
+            <div className={'ds-l-md-col--9'}>
               <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
                 <p className="dc-c-metadata-description" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}/>
               </div>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -138,11 +138,11 @@ const Dataset = ({
               <h1 className={'ds-h1 title-underline'}>{title}</h1>
             </div>
             <div className={'ds-l-md-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right'}>
-              <p>Updated <TransformedDate date={dataset.modified} /></p>
+              <p className="ds-u-margin--0">Updated <TransformedDate date={dataset.modified} /></p>
             </div>
             <div className={'ds-l-md-col--9'}>
               <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
-                <p className="dc-c-metadata-description" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}/>
+                <p className="dc-c-metadata-description ds-u-margin--0" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}/>
               </div>
             </div>
           </div>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -44,7 +44,7 @@ const Dataset = ({
   apiPageUrl = "/api",
   dataDictionaryUrl,
   borderlessTabs = false,
-  defaultPageSize = 25,
+  defaultPageSize = 25
 } : DatasetPageType) => {
   const options = location.search
     ? { ...qs.parse(location.search, { ignoreQueryPrefix: true }) }

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -135,7 +135,7 @@ const Dataset = ({
         <div className={'ds-l-container'}>
           <div className={'ds-l-row'}>
             <div className={'ds-l-md-col--9'}>
-              <h1 className={'ds-u-margin-bottom--4 ds-h1 title-underline'}>{title}</h1>
+              <h1 className={'ds-h1 title-underline'}>{title}</h1>
             </div>
             <div className={'ds-l-md-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right'}>
               <p>Updated <TransformedDate date={dataset.modified} /></p>

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -17,6 +17,7 @@ import ResourcePreview from '../../components/ResourcePreview';
 import ResourceFooter from '../../components/ResourceFooter';
 import { buildCustomColHeaders } from './functions';
 import QueryBuilder from './QueryBuilder';
+import TransformedDate from '../../components/TransformedDate';
 import 'swagger-ui-react/swagger-ui.css';
 
 const FilteredResourceBody = ({
@@ -84,6 +85,9 @@ const FilteredResourceBody = ({
             Back to {dataset.title}
           </Link>
           <h1 className="ds-title">{customTitle ? customTitle : pageTitle}</h1>
+          <div class="ds-l-row">
+            <span class="ds-l-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right">Updated <TransformedDate date={dataset.modified} /></span>
+          </div>
           <p
             className="ds-u-margin-top--0 dc-c-metadata-description"
             dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(distribution.data.description) }}

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -85,8 +85,8 @@ const FilteredResourceBody = ({
             Back to {dataset.title}
           </Link>
           <h1 className="ds-title">{customTitle ? customTitle : pageTitle}</h1>
-          <div class="ds-l-row">
-            <span class="ds-l-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right">Updated <TransformedDate date={dataset.modified} /></span>
+          <div className="ds-l-row">
+            <span className="ds-l-col--12 ds-u-color--gray ds-u-margin-y--1 ds-u-text-align--right">Updated <TransformedDate date={dataset.modified} /></span>
           </div>
           <p
             className="ds-u-margin-top--0 dc-c-metadata-description"

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -20,6 +20,7 @@ export type DatasetType = {
   identifier: string,
   describedBy?: any, // TODO
   describedByType?: any, //TODO
+  modified: string,
 }
 
 export type ConditionType = {


### PR DESCRIPTION
**Description**

Dataset pages and the filtered view page (/data) display the modified date in the top right corner below the dataset title.

**AC**

Display the modified date in the top right corner of the dataset page as "Updated March 27, 2024"
Also display on the /data page.

**Before**

![Screenshot 2024-04-01 at 5 05 44 PM](https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/69f49cc9-b87d-4b43-ab88-1c714bf608ba)

![Screenshot 2024-04-01 at 5 06 27 PM](https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/adbd4eaa-9c0a-4e2a-a832-5223dd33d467)

**After**

<img width="1453" alt="Screenshot 2024-04-02 at 11 35 52 AM" src="https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/65679b06-7876-41cd-bcd1-c654da22b161">

![Screenshot 2024-04-01 at 5 06 47 PM](https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/09f0844a-5df4-4b06-9b9e-80492c167020)

**To Test**

1. View a dataset page, ie: 
- http://localhost:3000/dataset/ebcfc16f-8291-4c61-82a4-055846d72f3a
- http://localhost:3000/dataset/ebcfc16f-8291-4c61-82a4-055846d72f3a/data
2. Confirm you see the modified date in the top right of the content region.