### PR TITLE
WCMS-20063 updates - increased icon size and added file extension to display text

### DIFF
--- a/src/components/Resource/Resource.test.jsx
+++ b/src/components/Resource/Resource.test.jsx
@@ -32,7 +32,7 @@ describe('<Resource />', () => {
         fileFormat={"csv"}
       />
     )
-    expect(screen.getByText("Test Custom Title")).toBeInTheDocument();
+    expect(screen.getByText("Test Custom Title (CSV)")).toBeInTheDocument();
     expect(screen.getByText("Test Custom Description")).toBeInTheDocument();
     expect(screen.getByRole("link", {name: "Download Test title csv"})).toBeInTheDocument();
   })

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -44,9 +44,9 @@ const Resource = ({ distributions, resource, title } : ResourcePropsType ) => {
               const fileFormat = getFormatType(dist)
               return (
                 <li key={dist.identifier} className={`ds-u-display--flex ds-u-flex-wrap--wrap ${fileFormat !== "csv" && "ds-u-margin-bottom--2"}`}>
-                  <div className="ds-u-font-weight--bold ds-u-font-size--lg ds-l-col--12 ds-l-md-col--6 ds-u-padding-left--0">
-                    <i className={'fa ds-u-color--primary ds-u-padding-right--1 ' + 'fa-file-' + (fileFormat == "xlsx" ? "excel" : fileFormat)}></i>
-                    {dist.data.title ? dist.data.title : title + " (" + fileFormat.toUpperCase() + ")"}
+                  <div className="ds-u-font-weight--bold ds-u-font-size--lg ds-l-col--12 ds-l-md-col--6 ds-u-padding-left--0 ds-u-align-items--center ds-u-display--flex">
+                    <i className={'fa ds-u-color--primary ds-u-padding-right--1 ds-u-font-size--3xl ' + 'fa-file-' + (fileFormat == "xlsx" ? "excel" : fileFormat)}></i>
+                    <p className="ds-u-margin-top--0">{dist.data.title ? dist.data.title : title}{" (" + fileFormat.toUpperCase() + ")"}</p>
                   </div>
                   <div className="ds-l-col--12 ds-l-md-col--6 ds-u-text-align--center ds-u-md-text-align--right ds-u-margin-top--2 ds-u-md-margin-top--0">
                     <a


### PR DESCRIPTION
## Before

![Screenshot 2024-04-10 at 4 55 28 PM](https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/89d8f950-4526-410a-a961-5470168db70b)

## After

![Screenshot 2024-04-10 at 5 00 11 PM](https://github.com/GetDKAN/cmsds-open-data-components/assets/261457/057df41e-a7bf-4b07-b836-a6a93a5486fd)

## To Test

1. visit http://localhost:3000/dataset/a217613c-12bc-5137-8b3a-ada0e4dad1ff#overview
2. compare to https://data.medicaid.gov/dataset/a217613c-12bc-5137-8b3a-ada0e4dad1ff#overview
3. verify visual changes