### PR TITLE
Show distribution descriptions like dataset descriptions

### DIFF
--- a/src/components/DatasetSearchListItem/index.tsx
+++ b/src/components/DatasetSearchListItem/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
+import truncate from 'lodash.truncate'
 import { Link } from 'react-router-dom';
 import DOMPurify from 'dompurify';
-import TextTruncate from 'react-text-truncate';
+// import TextTruncate from 'react-text-truncate';
 import { useMediaQuery } from 'react-responsive';
 import LargeFileDialog from '../LargeFileDialog';
 import SearchItemIcon from '../../assets/icons/searchItem';
@@ -49,14 +50,15 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
     linkClasses = 'ds-u-display--block ds-u-text-align--left';
   }
   
-  const truncatedDescription = (
-    <TextTruncate
-      line={3}
-      element={'p'}
-      truncateText="…"
-      text={prepDescription(description)}
-    />
-  );
+  // const truncatedDescription = (
+  //   <TextTruncate
+  //     line={3}
+  //     element={'p'}
+  //     truncateText="…"
+  //     text={prepDescription(description)}
+  //   />
+    
+  // );
 
   return (
     <li className="dc-c-search-list-item ds-u-padding-top--3">
@@ -70,7 +72,10 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
           </h2>
         </div>
         <div className="ds-l-row">
-          <div className="ds-l-col--12 ds-l-md-col--12">{truncatedDescription}</div>
+          <div className="ds-l-col--12 ds-l-md-col--12">{truncate(description, {
+            length: 80 * 3,
+            separator:  /[ (<br\/>)]+/
+          })}</div>
         </div>
         <ul className="ds-l-row ds-u-padding--0 ds-u-flex-direction--row ds-u-margin-top--4">
           <li className={linkContainerClasses}>

--- a/src/components/DatasetSearchListItem/index.tsx
+++ b/src/components/DatasetSearchListItem/index.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import truncate from 'lodash.truncate'
 import { Link } from 'react-router-dom';
 import DOMPurify from 'dompurify';
-// import TextTruncate from 'react-text-truncate';
+import TextTruncate from 'react-text-truncate';
 import { useMediaQuery } from 'react-responsive';
 import LargeFileDialog from '../LargeFileDialog';
 import SearchItemIcon from '../../assets/icons/searchItem';
@@ -50,15 +49,14 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
     linkClasses = 'ds-u-display--block ds-u-text-align--left';
   }
   
-  // const truncatedDescription = (
-  //   <TextTruncate
-  //     line={3}
-  //     element={'p'}
-  //     truncateText="…"
-  //     text={prepDescription(description)}
-  //   />
-    
-  // );
+  const truncatedDescription = (
+    <TextTruncate
+      line={3}
+      element={'p'}
+      truncateText="…"
+      text={prepDescription(description)}
+    />
+  );
 
   return (
     <li className="dc-c-search-list-item ds-u-padding-top--3">
@@ -72,10 +70,7 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
           </h2>
         </div>
         <div className="ds-l-row">
-          <div className="ds-l-col--12 ds-l-md-col--12">{truncate(description, {
-            length: 80 * 3,
-            separator:  /[ (<br\/>)]+/
-          })}</div>
+          <div className="ds-l-col--12 ds-l-md-col--12">{truncatedDescription}</div>
         </div>
         <ul className="ds-l-row ds-u-padding--0 ds-u-flex-direction--row ds-u-margin-top--4">
           <li className={linkContainerClasses}>

--- a/src/components/Resource/index.tsx
+++ b/src/components/Resource/index.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import DOMPurify from 'dompurify';
 import { useMediaQuery } from 'react-responsive';
 import { Button } from '@cmsgov/design-system';
 import ResourceInformation from '../ResourceInformation';
@@ -63,7 +64,9 @@ const Resource = ({ distributions, resource, title } : ResourcePropsType ) => {
                     </a>
                   </div>
                   {dist.data.description && (
-                    <p>{dist.data.description}</p>
+                    <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
+                      <p className="dc-c-metadata-description ds-u-margin--0" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dist.data.description) }}/>
+                    </div>
                   )}
                   {fileFormat === "csv" && <ResourceInformation resource={resource} />}
                 </li>


### PR DESCRIPTION
This PR just sets the distribution's description to look like the dataset description. This is to help datasets like https://data.medicaid.gov/dataset/d30cfc7c-4b32-4df1-b2bf-e0a850befd77#overview