### PR TITLE
Reset search pagination on fulltext/facet change

### DIFF
--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -139,11 +139,15 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
   }, [totalItems, pageSize, page]);
 
   useEffect(() => {
+    setPage(1)
+  }, [fulltext, selectedFacets]);
+
+  useEffect(() => {
     var params = buildSearchParams(true);
     if (params !== location.search) {
       setSearchParams(params);
     }
-  }, [page, sort, sortOrder, fulltext, selectedFacets]);
+  }, [page, sort, sortOrder]);
 
   function resetFilters() {
     setFullText(defaultFulltext);


### PR DESCRIPTION
An example of this would be visit https://data.medicaid.gov/datasets?page=5 and click on the `eligibility` facet. It is still trying to look at page 5. This is compared to https://data.healthcare.gov/datasets?page=5 and click on `Assisters`. 