### PR TITLE
Check for schema and set default to {} in useDatastore

### DIFF
--- a/src/services/useDatastore/useDatastore.jsx
+++ b/src/services/useDatastore/useDatastore.jsx
@@ -55,14 +55,16 @@ const useDatastore = (
   useEffect(() => {
     if(data) {
       const propertyKeys =
-        data.schema[id] && data.schema[id].fields
+        data.schema && data.schema[id] && data.schema[id].fields
           ? Object.keys(data.schema[id].fields)
           : [];
       setValues(data.results), setCount(data.count);
       if (propertyKeys.length) {
         setColumns(prepareColumns ? prepareColumns(propertyKeys) : propertyKeys);
       }
-      setSchema(data.schema);
+      if(data.schema) {
+        setSchema(data.schema);
+      }
     }
   }, [data])
 


### PR DESCRIPTION
If a dataset was visited before the cron tasks had built it there were two places looking at `schema[id]` could fail:

1. Line 58, needed to check for schema before checking for the id key
2. the original default for schema in useDatastore was an empty object, but on line 65 it would be set to null or undefined which would then break every component that was looking for keys in the resource.schema object. 