### PR TITLE
WCMS-20265: Enable Data Dictionary CSV Downloads with a prop

### DIFF
--- a/src/components/DatasetDataDictionaryTab/index.tsx
+++ b/src/components/DatasetDataDictionaryTab/index.tsx
@@ -10,13 +10,14 @@ import DatasetDictionaryTable from '../DatasetDictionaryTable';
 import { Button, Spinner } from '@cmsgov/design-system';
 
 const DataDictionary = (
-  { datasetDictionaryEndpoint, datasetSitewideDictionary, title, pageSize = 20, additionalParams } : 
+  { datasetDictionaryEndpoint, datasetSitewideDictionary, title, pageSize = 20, additionalParams, csvDownload } : 
   { 
     datasetDictionaryEndpoint: string,
     datasetSitewideDictionary: DatasetDictionaryItemType[]
     title: string,
     pageSize: number,
     additionalParams: any,
+    csvDownload : boolean
   }) => {
   
   const {data, isPending, error} = useQuery({
@@ -36,10 +37,22 @@ const DataDictionary = (
       <h2 className="ds-text-heading--2xl ds-u-margin-y--3">{title}</h2>
       {datasetDictionary && (
         <>
-          <div className="ds-u-margin-bottom--1 ds-u-display--flex ds-u-justify-content--end">
+          <div className="ds-u-margin-bottom--1 ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end">
             <Button className="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--4" onClick={() => window.open(datasetDictionaryEndpoint)} type="button" >
               <i className="fa fa-file-download ds-u-color--primary ds-u-padding-right--1"></i> View Dictionary JSON
             </Button>
+            {csvDownload && (
+              <div className="ds-l-col--12 ds-l-sm-col--6 ds-l-md-col--4 ds-u-margin-top--2 ds-u-sm-margin-top--0 ds-u-padding--0 ds-u-sm-padding-left--2">
+                <a
+                  href={datasetDictionaryEndpoint + "/csv"}
+                  className="ds-c-button"
+                  style={{width: '100%'}}
+                >
+                  <i className="fa fa-file-download ds-u-color--primary ds-u-padding-right--1"></i>
+                  Download Dictionary CSV
+                </a>
+              </div>
+            )}
           </div>
           <DatasetDictionaryTable datasetDictionary={datasetDictionary} pageSize={pageSize}/>
         </>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -45,7 +45,8 @@ const Dataset = ({
   apiPageUrl = "/api",
   dataDictionaryUrl,
   borderlessTabs = false,
-  defaultPageSize = 25
+  defaultPageSize = 25,
+  dataDictionaryCSV = false
 } : DatasetPageType) => {
   const options = location.search
     ? { ...qs.parse(location.search, { ignoreQueryPrefix: true }) }
@@ -197,7 +198,13 @@ const Dataset = ({
                       }
                       className={ borderlessTabs ? 'ds-u-border--0 ds-u-padding-x--0' : '' }
                     >
-                      <DataDictionary datasetSitewideDictionary={datasetSitewideDictionary} datasetDictionaryEndpoint={distribution.data.describedBy} title={"Data Dictionary"} additionalParams={additionalParams} />
+                      <DataDictionary
+                        datasetSitewideDictionary={datasetSitewideDictionary}
+                        datasetDictionaryEndpoint={distribution.data.describedBy}
+                        title={"Data Dictionary"}
+                        additionalParams={additionalParams}
+                        csvDownload={dataDictionaryCSV}
+                      />
                     </TabPanel>
                   )
                   : null}

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -67,7 +67,8 @@ export type DatasetPageType = {
   dataDictionaryUrl: string | undefined,
   dataDictionaryACA: string | undefined,
   borderlessTabs: boolean,
-  defaultPageSize: Number
+  defaultPageSize: Number,
+  dataDictionaryCSV: boolean,
 }
 
 


### PR DESCRIPTION
Can be enabled downstream by adding a "dataDictionaryCSV" prop to the <Dataset> component. Currently only enabled on medicaid.