### PR TITLE
WCMS-19554: Fix pagination Bugs

### DIFF
--- a/src/components/DataDictionaryTable/index.tsx
+++ b/src/components/DataDictionaryTable/index.tsx
@@ -152,9 +152,7 @@ const DataDictionaryTable = ({tableColumns, tableData, pageSize, columnFilters} 
             evt.preventDefault();
             table.setPageIndex(page - 1)
           }}
-          renderHref={(page) => {
-            return '';
-          }}
+          renderHref={(page) => `/page=${page}`}
         />
       ): ''}
     </div>

--- a/src/components/DatasetTableTab/index.tsx
+++ b/src/components/DatasetTableTab/index.tsx
@@ -88,15 +88,13 @@ const DatasetTable = ({isModal = false, closeFullScreenModal} : {isModal?: boole
           <div className="ds-u-display--flex ds-u-flex-wrap--wrap ds-u-justify-content--end ds-u-md-justify-content--between ds-u-margin-top--2 ds-u-align-items--center">
             <Pagination
               totalPages={Math.ceil(resource.count ? resource.count / pageSize : 1)}
-              currentPage={page}
+              currentPage={Number(page)}
               onPageChange={(evt, page) => {
                 evt.preventDefault();
                 setOffset((page - 1) * limit);
                 setPage(page);
               }}
-              renderHref={(page) => {
-                return '';
-              }}
+              renderHref={(p) => `?page=${p}`}
               className="ds-l-col--12 ds-u-padding-x--0"
             />
           </div>

--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -139,7 +139,8 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
   }, [totalItems, pageSize, page]);
 
   useEffect(() => {
-    setPage(1)
+    if (page !== 1 && (transformedParams.fulltext !== fulltext || transformedParams.selectedFacets !== selectedFacets))
+      setPage(1)
   }, [fulltext, selectedFacets]);
 
   useEffect(() => {


### PR DESCRIPTION
The pagination disabled bug seems to be a quirk/bug of the design system component - the renderHref prop needs to actually return something or else the Next and Previous buttons render as buttons instead of links, and their disabled styling isn't set up to render that correctly.


This PR also fixes a bug where page values on the /datasets page were not being respected by the app on a reload.