### PR TITLE
Add new dynamicDescription and customDescription to FilteredResource template

### DIFF
--- a/src/components/DatasetDescription/dataset-description.test.jsx
+++ b/src/components/DatasetDescription/dataset-description.test.jsx
@@ -1,14 +1,14 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import FilteredResourceDescription from './FilteredResourceDescription';
+import DatasetDescription from '.';
 import * as dataset from "../../tests/fixtures/dataset.json";
 import * as distributionWithTitle from "../../tests/fixtures/distributionWithTitle.json"
 
-describe('<FilteredResourceDescription />', () => {
+describe('<DatasetDescription />', () => {
   test("Renders with distribution description over dataset description", () => {
     render(
-      <FilteredResourceDescription
+      <DatasetDescription
         dataset={dataset}
         distribution={distributionWithTitle.distribution[0]}
       />
@@ -17,7 +17,7 @@ describe('<FilteredResourceDescription />', () => {
   });
   test("Renders dataset description", () => {
     render(
-      <FilteredResourceDescription
+      <DatasetDescription
         dataset={dataset}
         distribution={dataset.distribution[0]}
       />
@@ -25,7 +25,17 @@ describe('<FilteredResourceDescription />', () => {
     expect(screen.getByText("The data below contains newly reported, active covered outpatient drugs which were reported by participating drug manufacturers since the last quarterly update of the Drug Products in the Medicaid Drug Rebate Program (MDRP) database.")).toBeInTheDocument();
   });
   test("Doesn't render when no dataset or distribution is added", () => {
-    const { container } = render(<FilteredResourceDescription />);
+    const { container } = render(<DatasetDescription />);
     expect(container.innerHTML).toBe("");
+  });
+  test("Render new description if customDescription", () => {
+    render(
+      <DatasetDescription
+        dataset={dataset}
+        distribution={distributionWithTitle.distribution[0]}
+        customDescription={() => "My custom description."}
+      />
+    );
+    expect(screen.getByText("My custom description.")).toBeInTheDocument();
   });
 });

--- a/src/components/DatasetDescription/index.tsx
+++ b/src/components/DatasetDescription/index.tsx
@@ -1,25 +1,33 @@
 import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
+import { DatasetDescriptionType } from '../../types/dataset';
 
-const FilteredResourceDescription = ({distribution, dataset, resource, customDescription, dynamicDescription}) => {
+const DatasetDescription = (
+  {distribution, dataset, resource, customDescription, dynamicDescription, updateAriaLive} : DatasetDescriptionType
+) => {
   const [description, setDescription] = useState("");
 
-  if(!distribution && !dataset) {
+  if(!distribution && !dataset?.identifier) {
     return null;
   }
   useEffect(() => {
     if (!dynamicDescription && description !== "") {
       return;
     }
+    let newDescription = '';
     if (customDescription) {
-      setDescription(customDescription(dataset, distribution, resource));
+      newDescription = customDescription(dataset, distribution, resource);
     } else {
       if(distribution.data && distribution.data.description) {
-        setDescription(distribution.data.description);
+        newDescription = distribution.data.description;
       } else if(dataset.description) {
-        setDescription(dataset.description);
+        newDescription = dataset.description;
       }
     }
+    if (description !== newDescription && updateAriaLive) {
+      updateAriaLive(newDescription);
+    }
+    setDescription(newDescription);
   }, [resource, distribution, dataset, customDescription, dynamicDescription]);
   
   return (
@@ -32,4 +40,4 @@ const FilteredResourceDescription = ({distribution, dataset, resource, customDes
   );
 }
 
-export default FilteredResourceDescription;
+export default DatasetDescription;

--- a/src/components/DatasetDescription/index.tsx
+++ b/src/components/DatasetDescription/index.tsx
@@ -3,7 +3,7 @@ import DOMPurify from 'dompurify';
 import { DatasetDescriptionType } from '../../types/dataset';
 
 const DatasetDescription = (
-  {distribution, dataset, resource, customDescription, dynamicDescription, updateAriaLive} : DatasetDescriptionType
+  {distribution, dataset, resource, customDescription, updateAriaLive} : DatasetDescriptionType
 ) => {
   const [description, setDescription] = useState("");
 
@@ -11,9 +11,6 @@ const DatasetDescription = (
     return null;
   }
   useEffect(() => {
-    if (!dynamicDescription && description !== "") {
-      return;
-    }
     let newDescription = '';
     if (customDescription) {
       newDescription = customDescription(dataset, distribution, resource);
@@ -28,7 +25,7 @@ const DatasetDescription = (
       updateAriaLive(newDescription);
     }
     setDescription(newDescription);
-  }, [resource, distribution, dataset, customDescription, dynamicDescription]);
+  }, [resource, distribution, dataset, customDescription]);
   
   return (
     <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -163,9 +163,6 @@ const Dataset = ({
                 customDescription={customDescription}
                 updateAriaLive={updateAriaLive}
               />
-              {/* <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
-                <div className="dc-c-metadata-description ds-u-margin--0" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}/>
-              </div> */}
             </div>
           </div>
           <div className={'ds-l-row'}>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -53,7 +53,6 @@ const Dataset = ({
   disableTableControls = false,
   hideDataDictionary = false,
   customDescription,
-  dynamicDescription,
   updateAriaLive,
 } : DatasetPageType) => {
   const options = location.search
@@ -162,7 +161,6 @@ const Dataset = ({
                 dataset={dataset}
                 resource={resource}
                 customDescription={customDescription}
-                dynamicDescription={dynamicDescription}
                 updateAriaLive={updateAriaLive}
               />
               {/* <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -19,6 +19,7 @@ import { getFormatType } from '../../utilities/format';
 import './dataset.scss';
 import DataTableStateWrapper from '../../components/DatasetTableTab/DataTableStateWrapper';
 import DataTableContext from './DataTableContext';
+import DatasetDescription from '../../components/DatasetDescription';
 
 const getDataDictionary = (dataDictionaryUrl : string, additionalParams: any) => {
   const {data, isPending, error} = useQuery({
@@ -51,6 +52,9 @@ const Dataset = ({
   dataDictionaryBanner = false,
   disableTableControls = false,
   hideDataDictionary = false,
+  customDescription,
+  dynamicDescription,
+  updateAriaLive,
 } : DatasetPageType) => {
   const options = location.search
     ? { ...qs.parse(location.search, { ignoreQueryPrefix: true }) }
@@ -153,9 +157,17 @@ const Dataset = ({
               <p className="ds-u-margin--0">Updated <TransformedDate date={dataset.modified} /></p>
             </div>
             <div className={'ds-l-md-col--9'}>
-              <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
+              <DatasetDescription
+                distribution={distribution}
+                dataset={dataset}
+                resource={resource}
+                customDescription={customDescription}
+                dynamicDescription={dynamicDescription}
+                updateAriaLive={updateAriaLive}
+              />
+              {/* <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
                 <div className="dc-c-metadata-description ds-u-margin--0" dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(dataset.description) }}/>
-              </div>
+              </div> */}
             </div>
           </div>
           <div className={'ds-l-row'}>

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -10,7 +10,7 @@ import ResourceFooter from '../../components/ResourceFooter';
 import { buildCustomColHeaders } from './functions';
 import QueryBuilder from './QueryBuilder';
 import TransformedDate from '../../components/TransformedDate';
-import FilteredResourceDescription from './FilteredResourceDescription';
+import DatasetDescription from '../../components/DatasetDescription';
 import 'swagger-ui-react/swagger-ui.css';
 import DataTableContext from '../Dataset/DataTableContext';
 import ManageColumnsContext from '../../components/ManageColumns/ManageColumnsContext';
@@ -27,7 +27,8 @@ const FilteredResourceBody = ({
   customTitle,
   customDescription,
   dynamicDescription,
-  rootUrl
+  rootUrl,
+  updateAriaLive
 }) => {
   const [tablePadding, setTablePadding] = React.useState('ds-u-padding-y--1');
   let apiDocs = useRef();
@@ -84,12 +85,13 @@ const FilteredResourceBody = ({
             <p className="ds-u-margin--0">Updated <TransformedDate date={dataset.modified} /></p>
           </div>
           <div className={'ds-l-md-col--9'}>
-            <FilteredResourceDescription
+            <DatasetDescription
               distribution={distribution}
               dataset={dataset}
               resource={resource}
               customDescription={customDescription}
               dynamicDescription={dynamicDescription}
+              updateAriaLive={updateAriaLive}
             />
           </div>
           {Object.keys(resource).length && resource.columns && Object.keys(resource.schema).length && (

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -26,7 +26,6 @@ const FilteredResourceBody = ({
   columnWidths,
   customTitle,
   customDescription,
-  dynamicDescription,
   rootUrl,
   updateAriaLive
 }) => {
@@ -90,7 +89,6 @@ const FilteredResourceBody = ({
               dataset={dataset}
               resource={resource}
               customDescription={customDescription}
-              dynamicDescription={dynamicDescription}
               updateAriaLive={updateAriaLive}
             />
           </div>

--- a/src/templates/FilteredResource/FilteredResourceBody.jsx
+++ b/src/templates/FilteredResource/FilteredResourceBody.jsx
@@ -25,6 +25,8 @@ const FilteredResourceBody = ({
   columnSettings,
   columnWidths,
   customTitle,
+  customDescription,
+  dynamicDescription,
   rootUrl
 }) => {
   const [tablePadding, setTablePadding] = React.useState('ds-u-padding-y--1');
@@ -82,7 +84,13 @@ const FilteredResourceBody = ({
             <p className="ds-u-margin--0">Updated <TransformedDate date={dataset.modified} /></p>
           </div>
           <div className={'ds-l-md-col--9'}>
-            <FilteredResourceDescription distribution={distribution} dataset={dataset} />
+            <FilteredResourceDescription
+              distribution={distribution}
+              dataset={dataset}
+              resource={resource}
+              customDescription={customDescription}
+              dynamicDescription={dynamicDescription}
+            />
           </div>
           {Object.keys(resource).length && resource.columns && Object.keys(resource.schema).length && (
             <div className={'ds-l-md-col--12'}>

--- a/src/templates/FilteredResource/FilteredResourceDescription.jsx
+++ b/src/templates/FilteredResource/FilteredResourceDescription.jsx
@@ -1,17 +1,27 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 
-const FilteredResourceDescription = ({distribution, dataset}) => {
+const FilteredResourceDescription = ({distribution, dataset, resource, customDescription, dynamicDescription}) => {
+  const [description, setDescription] = useState("");
+
   if(!distribution && !dataset) {
     return null;
   }
-  let description = "";
-  if(distribution.data && distribution.data.description) {
-    description = distribution.data.description;
-  } else if(dataset.description) {
-    description = dataset.description
-  }
-
+  useEffect(() => {
+    if (!dynamicDescription && description !== "") {
+      return;
+    }
+    if (customDescription) {
+      setDescription(customDescription(dataset, distribution, resource));
+    } else {
+      if(distribution.data && distribution.data.description) {
+        setDescription(distribution.data.description);
+      } else if(dataset.description) {
+        setDescription(dataset.description);
+      }
+    }
+  }, [resource, distribution, dataset, customDescription, dynamicDescription]);
+  
   return (
     <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
       <div 

--- a/src/templates/FilteredResource/index.jsx
+++ b/src/templates/FilteredResource/index.jsx
@@ -18,7 +18,8 @@ const FilteredResource = ({
   customTitle,
   customDescription,
   dynamicDescription,
-  rootUrl
+  rootUrl,
+  updateAriaLive
 }) => {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState(false);
@@ -77,6 +78,7 @@ const FilteredResource = ({
               customDescription={customDescription}
               dynamicDescription={dynamicDescription}
               rootUrl={rootUrl}
+              updateAriaLive={updateAriaLive}
             />
           )}
         </>

--- a/src/templates/FilteredResource/index.jsx
+++ b/src/templates/FilteredResource/index.jsx
@@ -17,7 +17,6 @@ const FilteredResource = ({
   columnWidths,
   customTitle,
   customDescription,
-  dynamicDescription,
   rootUrl,
   updateAriaLive
 }) => {
@@ -76,7 +75,6 @@ const FilteredResource = ({
               columnWidths={columnWidths}
               customTitle={customTitle}
               customDescription={customDescription}
-              dynamicDescription={dynamicDescription}
               rootUrl={rootUrl}
               updateAriaLive={updateAriaLive}
             />

--- a/src/templates/FilteredResource/index.jsx
+++ b/src/templates/FilteredResource/index.jsx
@@ -16,6 +16,8 @@ const FilteredResource = ({
   columnSettings,
   columnWidths,
   customTitle,
+  customDescription,
+  dynamicDescription,
   rootUrl
 }) => {
   const [ready, setReady] = useState(false);
@@ -72,6 +74,8 @@ const FilteredResource = ({
               columnSettings={columnSettings}
               columnWidths={columnWidths}
               customTitle={customTitle}
+              customDescription={customDescription}
+              dynamicDescription={dynamicDescription}
               rootUrl={rootUrl}
             />
           )}

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -71,6 +71,9 @@ export type DatasetPageType = {
   dataDictionaryBanner: boolean,
   disableTableControls: boolean,
   hideDataDictionary: boolean,
+  customDescription?: Function,
+  dynamicDescription?: boolean,
+  updateAriaLive?: Function,
 }
 
 
@@ -122,4 +125,13 @@ export type DatasetDictionaryType = {
   data: {
     fields: DatasetDictionaryItemType[]
   }
+}
+
+export type DatasetDescriptionType = {
+  distribution: DistributionType,
+  dataset: DatasetType,
+  resource: ResourceType,
+  customDescription?: Function,
+  dynamicDescription?: boolean
+  updateAriaLive?: Function,
 }

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -72,7 +72,6 @@ export type DatasetPageType = {
   disableTableControls: boolean,
   hideDataDictionary: boolean,
   customDescription?: Function,
-  dynamicDescription?: boolean,
   updateAriaLive?: Function,
 }
 
@@ -132,6 +131,5 @@ export type DatasetDescriptionType = {
   dataset: DatasetType,
   resource: ResourceType,
   customDescription?: Function,
-  dynamicDescription?: boolean
   updateAriaLive?: Function,
 }


### PR DESCRIPTION
Some of the datasets need descriptions to match the current conditions added when viewing the /data route. This PR adds two new properties to the FilteredResource template. One is dynamicDescription which is a boolean to let the description component know if it should update on any change of the page's data. The other is customDescription which is a function that takes the parameters dataset, distribution, and resource. This allows a custom function on the child site to control the description, like firing only on specific datasets and when certain conditions are met. 