### PR TITLE
Fix mobile scroll to to top bug

### DIFF
--- a/src/templates/Header/index.tsx
+++ b/src/templates/Header/index.tsx
@@ -45,7 +45,7 @@ const Header = (props: HeaderProps) => {
 
   function handleClick(event: MouseEvent) {
     // Links are wrapped in spans, this checks if the parent is an A, also check if in the search modal.    
-    if (menu.current && !menu.current.contains(event.target as HTMLElement)) {
+    if (mobileMenuOpen && menu.current && !menu.current.contains(event.target as HTMLElement)) {
       setMobileMenuOpen(false);
       closeMobileMenu()
     }


### PR DESCRIPTION
This is on 3.6.2-alpha.1.

To test:

1. Update one of the sites with the new header to the new alpha version
2. Build the site
3. The header should work in desktop still
4. Shrink the site to mobile
5. Visit the /datasets page
6. Scroll to the bottom of the page and click a link
7. The site should no longer scroll back to the main menu button. 
8. You should also be able to interact with the dataset pages in mobile view too
