### PR TITLE
WCMS-21351: Display unfiltered rows and columns on Dataset Overview page

### DIFF
--- a/src/components/ResourceInformation/index.tsx
+++ b/src/components/ResourceInformation/index.tsx
@@ -2,19 +2,19 @@ import React from 'react';
 import { ResourceType } from '../../types/dataset';
 
 const ResourceInformation = ({ resource } : {resource: ResourceType}) => {
-  const { count, columns } = resource;
+  const { totalRows, totalColumns } = resource;
   return (
     <div className="dc-c-resource-info-table ds-l-col--12 ds-u-padding-left--0 ds-u-margin-y--2">
       <h3 className="ds-u-font-size--base ds-text-heading--xl ds-text-heading--xl">About this Resource</h3>
       <div className="ds-u-display--flex ds-u-text-align--center ds-u-justify-content--center ds-u-md-justify-content--start">
         <div className="ds-u-fill--gray-lightest ds-u-radius ds-u-margin-right--1 ds-u-padding--2">
           <div className="ds-u-padding-top--05">Rows</div>
-          <div className="ds-u-font-weight--bold">{count ? count.toLocaleString() : ''}</div>
+          <div className="ds-u-font-weight--bold">{totalRows.toLocaleString()}</div>
         </div>
         <div className="ds-u-fill--gray-lightest ds-u-radius ds-u-margin-right--1 ds-u-padding--2">
           <div>
             <div className="ds-u-padding-top--05">Columns</div>
-            <div className="ds-u-font-weight--bold">{columns.length.toLocaleString()}</div>
+            <div className="ds-u-font-weight--bold">{totalColumns.toLocaleString()}</div>
           </div>
         </div>
       </div>

--- a/src/tests/fixtures/resource.json
+++ b/src/tests/fixtures/resource.json
@@ -627,6 +627,8 @@
       "drug_reactivation_date",
       "date_reported_to_cms"
   ],
+  "totalRows": 69,
+  "totalColumns": 22,
   "limit": 25,
   "offset": 0,
   "schema": {

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -79,6 +79,8 @@ export type DatasetPageType = {
 export type ResourceType = {
   columns: Array<string>,
   count: number | null,
+  totalRows: number,
+  totalColumns: number,
   limit: number,
   offset: number,
   loading: boolean,


### PR DESCRIPTION
This PR adds another fetch request to specifically gather unfiltered data so we can provide a stable rows / columns number on the DatasetOverview tab