### PR TITLE
Update swagger info tags using swagger-ui-layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.6.3",
       "license": "GPL-3.0",
       "dependencies": {
+        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.1",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -1948,6 +1949,17 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.0.2.tgz",
       "integrity": "sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw=="
+    },
+    "node_modules/@civicactions/swagger-ui-layout": {
+      "version": "0.2.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.1.tgz",
+      "integrity": "sha512-CfhDJjdKoRJBthEMKQq696E/G2sYHQt5Vwu+nZvMqd0KykuE4RhK+QshDXMwc84YSPOL83iAdlfhfzBF3SzwSA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "swagger-ui-react": "^5.11.3"
+      }
     },
     "node_modules/@cmsgov/design-system": {
       "version": "10.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.1",
+        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.2",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -1951,9 +1951,9 @@
       "integrity": "sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw=="
     },
     "node_modules/@civicactions/swagger-ui-layout": {
-      "version": "0.2.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.1.tgz",
-      "integrity": "sha512-CfhDJjdKoRJBthEMKQq696E/G2sYHQt5Vwu+nZvMqd0KykuE4RhK+QshDXMwc84YSPOL83iAdlfhfzBF3SzwSA==",
+      "version": "0.2.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.2.tgz",
+      "integrity": "sha512-4W41O+Z60U1o10ln0PJEyz/aEBRPsrGQyIr4lzUud+UURtvP3ahEBZ7eRukGE0VnAfvLwZshDin49pfLt3yZtg==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.3",
+        "@civicactions/swagger-ui-layout": "^0.2.0",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -1951,9 +1951,9 @@
       "integrity": "sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw=="
     },
     "node_modules/@civicactions/swagger-ui-layout": {
-      "version": "0.2.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.3.tgz",
-      "integrity": "sha512-W8RKAjzJ7QxpMB8+C0jBMiaWDcs5GJAM6cmCvCa8OUO1AQsGOO6V3LZmJ2BpvPILjrbiit4jFH0ffxqhJJagbA==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0.tgz",
+      "integrity": "sha512-m0kid1dSCnquFL6M7IWFOVNqkrdRVdscIXBb7rFS629YF9qBqAeUmU7LWJtG03zHl8PFxZ06zCUxdUB6FSgXZw==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^18.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.3",
       "license": "GPL-3.0",
       "dependencies": {
-        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.2",
+        "@civicactions/swagger-ui-layout": "^0.2.0-alpha.3",
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/modifiers": "^7.0.0",
         "@dnd-kit/sortable": "^8.0.0",
@@ -1951,9 +1951,9 @@
       "integrity": "sha512-NVf/1YycDMs6+FxS0Tb/W8MjJRDQdXF+tBfDtZ5UZeiRUkTmwKc4vmYCKZTyymfJk1gnMsauvZSX/HiV9jOABw=="
     },
     "node_modules/@civicactions/swagger-ui-layout": {
-      "version": "0.2.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.2.tgz",
-      "integrity": "sha512-4W41O+Z60U1o10ln0PJEyz/aEBRPsrGQyIr4lzUud+UURtvP3ahEBZ7eRukGE0VnAfvLwZshDin49pfLt3yZtg==",
+      "version": "0.2.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@civicactions/swagger-ui-layout/-/swagger-ui-layout-0.2.0-alpha.3.tgz",
+      "integrity": "sha512-W8RKAjzJ7QxpMB8+C0jBMiaWDcs5GJAM6cmCvCa8OUO1AQsGOO6V3LZmJ2BpvPILjrbiit4jFH0ffxqhJJagbA==",
       "license": "Apache-2.0",
       "peerDependencies": {
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
+    "@civicactions/swagger-ui-layout": "^0.1.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
-    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.1",
+    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.2",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
-    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.3",
+    "@civicactions/swagger-ui-layout": "^0.2.0",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
-    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.2",
+    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.3",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "author": "",
   "license": "GPL-3.0",
   "dependencies": {
-    "@civicactions/swagger-ui-layout": "^0.1.0",
+    "@civicactions/swagger-ui-layout": "^0.2.0-alpha.1",
     "@dnd-kit/core": "^6.1.0",
     "@dnd-kit/modifiers": "^7.0.0",
     "@dnd-kit/sortable": "^8.0.0",

--- a/src/components/ApiDocumentation/index.jsx
+++ b/src/components/ApiDocumentation/index.jsx
@@ -1,12 +1,16 @@
 import React from 'react';
 import SwaggerUI from 'swagger-ui-react';
+import { SpanOpenAPIVersion, SpanVersionStamp } from '@civicactions/swagger-ui-layout';
 import 'swagger-ui-react/swagger-ui.css';
 import '../../templates/APIPage/swagger-ui-overrides.scss';
 
 const ApiDocumentation = ({ endpoint }) => {
   return (
     <div>
-      <SwaggerUI url={endpoint} />
+      <SwaggerUI
+        url={endpoint}
+        plugins={[SpanOpenAPIVersion, SpanVersionStamp]}
+      />
     </div>
   );
 };

--- a/src/templates/APIPage/APIPage.jsx
+++ b/src/templates/APIPage/APIPage.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import qs from 'qs';
 import SwaggerUI from 'swagger-ui-react';
+import { SpanOpenAPIVersion, SpanVersionStamp } from '@civicactions/swagger-ui-layout';
 import ApiRowLimitNotice from '../../components/ApiRowLimitNotice';
 import 'swagger-ui-react/swagger-ui.css';
 import './swagger-ui-overrides.scss';
@@ -20,6 +21,7 @@ const APIPage = ({ hideAuth = true, additionalParams, rootUrl, showRowLimitNotic
           url={`${rootUrl}${qs.stringify(params, { addQueryPrefix: true })}`}
           docExpansion={'list'}
           defaultModelsExpandDepth={-1}
+          plugins={[SpanOpenAPIVersion, SpanVersionStamp]}
         />
       </section>
     </>

--- a/src/templates/APIPage/swagger-ui-overrides.scss
+++ b/src/templates/APIPage/swagger-ui-overrides.scss
@@ -69,11 +69,19 @@ This document provides overrides to Swagger UI, fixing accessibility issues.
   }
 
   .info {
-    .title {
-      small {
+    .title > span {
+      span {
         background-color: #666;
-
-        &.version-stamp {
+        border-radius: 67px;
+        display: inline-block;
+        font-size: 14px;
+        color: white;
+        margin: 0 0 0 5px;
+        padding: 2px 8px;
+        position: relative;
+        top: -5px;
+        vertical-align: super;
+        &.version-stamp--openapi {
           background-color: #005830;
         }
       }


### PR DESCRIPTION
This PR adds the new Swagger UI Layout library and updates the info tags to use spans instead of pre and small elements. 

This can't be merged until the swagger ui layout release is made. When using an npm workspace, you should be able to clone https://github.com/GetDKAN/swagger-ui-layout/pull/2 and then run this against a site. It uses the Swagger plugin system to overwrite components during render so there is only config and css necessary to setup here. 