### PR TITLE
WCMS-23623: update cursor from pointer to defaut

### DIFF
--- a/src/components/Datatable/datatable.scss
+++ b/src/components/Datatable/datatable.scss
@@ -13,7 +13,7 @@
   thead th div {
     display: flex;
     align-items: center;
-    cursor: pointer;
+    cursor: default;
   }
 }
 


### PR DESCRIPTION
Updated the CSS selector - thead th div - in the datatable.scss file to change the cursor style from pointer to default. This adjustment ensures that table headers do not appear interactive when they are not intended to be clickable.