### PR TITLE
25747: Bugfix for the dataset submenu items count.

### DIFF
--- a/src/components/DatasetListSubmenu/DatasetListSubmenu.tsx
+++ b/src/components/DatasetListSubmenu/DatasetListSubmenu.tsx
@@ -1,12 +1,11 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { useSearchParams, useLocation, Link } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import qs from 'qs';
 import axios from 'axios';
 import withQueryProvider from '../../utilities/QueryProvider/QueryProvider';
 import { Spinner, Alert } from '@cmsgov/design-system';
 import DatasetListSubmenuItem from '../DatasetListSubmenuItem';
 import { useQuery } from '@tanstack/react-query';
-import { transformUrlParamsToSearchObject } from '../../services/useSearchAPI/helpers';
 
 import "./dataset-list-submenu.scss";
 import { DatasetSubmenuListProps } from '../../types/search';
@@ -18,91 +17,32 @@ const DatasetListSubmenu = ({
   enablePagination = true,
   defaultPageSize = 4,
   defaultSort = { defaultSort: 'modified', defaultOrder: 'desc' },
-  dataDictionaryLinks = false,
   location,
   subLinkClasses
 }: DatasetSubmenuListProps) => {
   const { ACA } = useContext(ACAContext);
 
-  const defaultSortBy = "";
-  const defaultSortOrder = "";
-  const defaultPage = 1;
-
-  const transformedParams = transformUrlParamsToSearchObject(location.search, defaultSort);
-
   const [currentResultNumbers, setCurrentResultNumbers] = useState({ total: 0, startingNumber: 0, endingNumber: 0 });
   const [noResults, setNoResults] = useState(false);
   const [announcementText, setAnnouncementText] = useState('');
-  let [searchParams, setSearchParams] = useSearchParams();
   const [totalItems, setTotalItems] = useState(0);
-  const [page, setPage] = useState(transformedParams.page ? transformedParams.page : defaultPage);
-  const [sort, setSort] = useState(
-    transformedParams.sort ? transformedParams.sort : defaultSort ? defaultSort.defaultSort : defaultSortBy
-  );
-  const [sortOrder, setSortOrder] = useState(
-    transformedParams.sortOrder
-      ? transformedParams.sortOrder
-      : defaultSort ? defaultSort.defaultOrder : defaultSortOrder
-  );
 
   const pageSize = defaultPageSize;
 
   useEffect(() => {
-
-    // Update browser URL with current search params
-    const params = buildSearchParams(true);
-    const url = new URL(window.location.href);
-    window.history.pushState({}, '', `${url.origin}${url.pathname}${params}`);
-
-    const baseNumber = Number(totalItems) > 0 ? 1 : 0;
-    const startingNumber = baseNumber + (Number(pageSize) * Number(page) - Number(pageSize));
-    const endingNumber = Number(pageSize) * Number(page);
-
-    setCurrentResultNumbers({
-      total: Number(totalItems),
-      startingNumber: Number(totalItems) >= startingNumber ? startingNumber : 0,
-      endingNumber: Number(totalItems) < endingNumber ? Number(totalItems) : endingNumber,
-    });
-
-    setTimeout(() => {
-      setAnnouncementText(`Showing ${startingNumber} to ${endingNumber} of ${totalItems} datasets`);
-    }, 100);
-
     if (totalItems <= 0 && currentResultNumbers !== null) {
       setNoResults(true);
     } else {
       setNoResults(false);
     }
-  }, [totalItems, pageSize, page]);
-
-  useEffect(() => {
-    var params = buildSearchParams(true);
-    if (params !== location.search) {
-      setSearchParams(params);
-    }
-  }, [page, sort, sortOrder]);
-
-
-  function buildSearchParams(includePage: boolean) {
-    let newParams: any = {};
-    if (Number(page) !== 1 && includePage) {
-      newParams.page = page;
-    }
-    if (sort !== defaultSort.defaultSort) {
-      newParams.sort = sort;
-    }
-    if (sortOrder !== defaultSort.defaultOrder) {
-      newParams.sortOrder = sortOrder;
-    }
-    return qs.stringify(newParams, { addQueryPrefix: includePage, encode: true });
-  }
+  }, [totalItems, pageSize]);
 
   let params = {
-    sort: sort ? sort : undefined,
-    ['sort-order']: sortOrder ? sortOrder : undefined,
-    page: page !== 1 ? page : undefined,  //use index except for when submitting to Search API
-    ['page-size']: pageSize !== 10 ? pageSize : undefined,
+    sort: defaultSort.defaultSort,
+    ['sort-order']: defaultSort.defaultOrder, // Display the default sort order of newest items first.
+    ['page-size']: defaultPageSize, // Only show 4 items in the submenu.
   }
+
   const { data, isPending, error } = useQuery({
     queryKey: ["datasets", params],
     queryFn: () => {
@@ -110,7 +50,14 @@ const DatasetListSubmenu = ({
     }
   });
 
-  if ((data && data.data.total) && totalItems != data.data.total) setTotalItems(data.data.total);
+  let submenuItemsCount = 0;
+
+  if (data) {
+    if (data.data.total && totalItems != data.data.total) setTotalItems(data.data.total);
+    let resultsCount = Object.keys(data.data.results).length;
+    // For the submenu pager, If there are less than 4 dataset item, display the dataset item count, otherwise, show "Viewing 4..".
+    submenuItemsCount = resultsCount > defaultPageSize ? defaultPageSize : resultsCount
+  }
 
   return (
     <>
@@ -145,9 +92,9 @@ const DatasetListSubmenu = ({
                 <>
                   <div className="">
                     <p className="ds-u-margin-y--0 ds-u-font-size--sm" aria-hidden="true">
-                      {(currentResultNumbers && data) && (
+                      {(data) && (
                         <>
-                          Viewing {currentResultNumbers.endingNumber} of {data.data.total}
+                          Viewing {submenuItemsCount} of {data.data.total}
                         </>
                       )}
                     </p>


### PR DESCRIPTION
**Bug**: The results count text in submenu dropdowns changes on paginated search pages. 
**Solution**:
This PR fixes the error by removing the unnecessary search params calculations on dataset search pages. Because the submenu will always display the newest items first, and only the first four items. We can set the API query to use a specific sortOrder and pageSize.