### PR TITLE
WCMS-25886: Improve UX for datasets that don't have a datastore table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/assets/icons/searchItem.tsx
+++ b/src/assets/icons/searchItem.tsx
@@ -14,6 +14,7 @@ const SearchItemIcon = (props: IconProps) => {
           version="1.1"
           xmlns="http://www.w3.org/2000/svg"
           xmlnsXlink="http://www.w3.org/1999/xlink"
+          aria-hidden="true"
         >
           <title>Overview Icon</title>
           <g stroke="none" strokeWidth="1" fillRule="evenodd">
@@ -41,6 +42,7 @@ const SearchItemIcon = (props: IconProps) => {
           version="1.1"
           xmlns="http://www.w3.org/2000/svg"
           xmlnsXlink="http://www.w3.org/1999/xlink"
+          aria-hidden="true"
         >
           <title>Data Table Icon</title>
           <g stroke="none" strokeWidth="1" fillRule="evenodd">
@@ -63,6 +65,7 @@ const SearchItemIcon = (props: IconProps) => {
           version="1.1"
           xmlns="http://www.w3.org/2000/svg"
           xmlnsXlink="http://www.w3.org/1999/xlink"
+          aria-hidden="true"
         >
           <title>API Icon</title>
           <g stroke="none" strokeWidth="1" fillRule="evenodd">
@@ -85,6 +88,7 @@ const SearchItemIcon = (props: IconProps) => {
           version="1.1"
           xmlns="http://www.w3.org/2000/svg"
           xmlnsXlink="http://www.w3.org/1999/xlink"
+          aria-hidden="true"
         >
           <title>Download Icon</title>
           <g stroke="none" strokeWidth="1" fillRule="evenodd">
@@ -98,7 +102,7 @@ const SearchItemIcon = (props: IconProps) => {
       );
     case 'data-dictionary':
       return (
-        <svg width="14px" height="16px" viewBox="0 0 14 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink">
+        <svg width="14px" height="16px" viewBox="0 0 14 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlnsXlink="http://www.w3.org/1999/xlink" aria-hidden="true">
           <title>Data Dictionary Icon</title>
           <g id="Dev-Handoff" stroke="none" strokeWidth="1" fillRule="evenodd">
               <g id="Group-15" transform="translate(0, 0)" fillRule="nonzero">

--- a/src/components/DatasetSearchListItem/dataset-search-list-item.scss
+++ b/src/components/DatasetSearchListItem/dataset-search-list-item.scss
@@ -38,4 +38,25 @@
     }
 
   }
+
+  .dkan-disabled-link-wrapper {
+    cursor: not-allowed;
+
+    .dkan-disabled-link {
+      pointer-events: none;
+      color: #757575;
+
+      &:active, &:hover, &:focus {
+        color: #757575;
+
+        svg {
+          fill: #757575;
+        }
+      }
+
+      svg {
+        fill: #757575;
+      }
+    }
+  }
 }

--- a/src/components/DatasetSearchListItem/datasetsearchlistitem.test.jsx
+++ b/src/components/DatasetSearchListItem/datasetsearchlistitem.test.jsx
@@ -61,7 +61,7 @@ describe('<DatasetSearchListItem />', () => {
         />
       </MemoryRouter>
     );
-    expect(screen.getByRole('link', { name: 'Download Icon Download' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Download' })).toBeInTheDocument();
   });
 
   test('Renders themes when showTopics is true', () => {

--- a/src/components/DatasetSearchListItem/index.tsx
+++ b/src/components/DatasetSearchListItem/index.tsx
@@ -6,8 +6,10 @@ import SearchItemIcon from '../../assets/icons/searchItem';
 import TransformedDate from '../TransformedDate';
 import './dataset-search-list-item.scss';
 import { truncateText } from './truncateText';
-import { Button } from '@cmsgov/design-system';
+import { Button, Tooltip } from '@cmsgov/design-system';
 import DatasetDate from '../DatasetDate';
+import { getFormatType } from '../../utilities/format';
+import { DistributionType } from '../../types/dataset';
 
 type LocationType = {
   pathname: string;
@@ -32,6 +34,7 @@ type SearchItemProps = {
   theme?: string[];
   topicSlugs?: { [key: string]: string }; // Map of topic titles to their slugs
   location: LocationType;
+  distribution: DistributionType | {};
 }
 
 const DatasetSearchListItem = (props: SearchItemProps) => {
@@ -51,6 +54,7 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
     showTopics = false,
     theme,
     topicSlugs,
+    distribution,
   } = props;
 
   const location = useLocation();
@@ -106,6 +110,70 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
 
   const url = `/dataset/${identifier}`
 
+  const DataTableLink: React.FC = () => {
+    if (getFormatType(distribution as DistributionType) === "csv") {
+      return (
+        <Link to={`${url}#data-table`}>
+          <SearchItemIcon id="data-table" />
+          Data Table
+        </Link>
+      )
+    }
+
+    return (
+      <Tooltip
+        className="dkan-disabled-link"
+        component="a"
+        offset={[
+          0,
+          5
+        ]}
+        title="There is no Data Table associated with this dataset. Data Tables will only display for CSV files."
+        aria-disabled="true"
+      >
+        <SearchItemIcon id="data-table" />
+        Data Table
+      </Tooltip>
+    )
+  }
+
+  const dataDictionaryExists = (): boolean => {
+    if ("data" in distribution) {
+      if ("describedBy" in distribution.data && "describedByType" in distribution.data) {
+        return distribution.data.describedByType === 'application/vnd.tableschema+json';
+      }
+    }
+
+    return false;
+  }
+
+  const DataDictionaryLink: React.FC = () => {
+    if (dataDictionaryExists()) {
+      return (
+        <Link to={`${url}#data-dictionary`}>
+          <SearchItemIcon id="data-dictionary" />
+          Data Dictionary
+        </Link>
+      )
+    }
+
+    return (
+      <Tooltip
+        className="dkan-disabled-link"
+        component="a"
+        offset={[
+          0,
+          5
+        ]}
+        title="There is no Data Dictionary associated with this dataset."
+        aria-disabled="true"
+      >
+        <SearchItemIcon id="data-dictionary" />
+        Data Dictionary
+      </Tooltip>
+    )
+  }
+
   return (
     <li className="dc-c-search-list-item ds-u-padding-top--3">
       <div className={`dc-c-searchlist-item ${paginationEnabled ? 'ds-u-border-top--1' : 'ds-u-border-bottom--1 ds-u-padding-bottom--3'}`}>
@@ -146,11 +214,8 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
           )}
         <ul className={`ds-l-row ds-u-padding--0 ds-u-flex-direction--row ds-u-justify-content--between ds-u-md-justify-content--start ds-u-margin-top--3 ds-u-margin-x--0 ${!dataDictionaryLinks ? 'ds-u-justify-content--center ds-u-md-justify-content--start' : ''}`}>
           <li className={linkContainerClasses}>
-            <span className={linkClasses}>
-              <Link to={`${url}#data-table`}>
-                <SearchItemIcon id="data-table" />
-                Data Table
-              </Link>
+            <span className={`${linkClasses}${getFormatType(distribution as DistributionType) === "csv" ? '' : ' dkan-disabled-link-wrapper'}`}>
+              <DataTableLink />
             </span>
           </li>
           <li className={linkContainerClasses}>
@@ -163,11 +228,8 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
           </li>
           { dataDictionaryLinks ? (
             <li className={linkContainerClasses}>
-              <span className={linkClasses}>
-              <Link to={`${url}#data-dictionary`}>
-                <SearchItemIcon id="data-dictionary" />
-                Data Dictionary
-              </Link>
+              <span className={`${linkClasses}${dataDictionaryExists() ? '' : ' dkan-disabled-link-wrapper'}`}>
+                <DataDictionaryLink />
               </span>
             </li>
           ) : ''}

--- a/src/components/LargeFileDialog/LargeFileDialog.test.js
+++ b/src/components/LargeFileDialog/LargeFileDialog.test.js
@@ -6,14 +6,14 @@ import LargeFileDialog from './index';
 describe("<LargeFileDialog />", () => {
   test('Renders correctly', () => {
     render(<LargeFileDialog downloadUrl="test" />);
-    expect(screen.getByRole('button', { name: "Download Icon Download" }));
+    expect(screen.getByRole('button', { name: "Download" }));
   });
   test('Opens and Closes correctly', () => {
     window.scrollTo = jest.fn();
     
     render(<LargeFileDialog downloadUrl="test" />);
 
-    fireEvent.click(screen.getByRole('button', { name: "Download Icon Download" }));
+    fireEvent.click(screen.getByRole('button', { name: "Download" }));
     expect(screen.getByRole('link', { name: "Yes, download" }));
     
     fireEvent.click(screen.getByRole('button', { name: "Close modal dialog" }));

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -200,7 +200,7 @@ const Dataset = ({
                           <DataTableStateWrapper />
                         </DataTableContext.Provider>
                       ) : (
-                        <p>There is no Data Table associated with this dataset. Data Tables will only display for CSV files</p>
+                        <p>There is no Data Table associated with this dataset. Data Tables will only display for CSV files.</p>
                       )
                     }
                   </TabPanel>

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -142,6 +142,7 @@ const Dataset = ({
   }, [distribution, window.location.hash])
 
   const displayDataDictionaryTab = ((distribution.data && distribution.data.describedBy && distribution.data.describedByType === 'application/vnd.tableschema+json') || (datasetSitewideDictionary && datasetSitewideDictionary.length > 0)) as boolean;
+  const formatType = getFormatType(distribution);
 
   return (
     <>
@@ -175,30 +176,34 @@ const Dataset = ({
                   }}
                   selectedId={selectedTab}
                 >
-                  {getFormatType(distribution) === "csv" && (
-                    <TabPanel
-                      id={'data-table'}
-                      tab={
-                        <span className="ds-u-color--primary">
-                          <SearchItemIcon id="data-table" />
-                          Data Table
-                        </span>
-                      }
-                      className={borderlessTabs ? 'ds-u-border--0 ds-u-padding-x--0' : ''}
-                    >
-                      <DataTableContext.Provider value={{
-                        id: id,
-                        resource: resource,
-                        distribution: distribution,
-                        rootUrl: rootUrl,
-                        customColumns: customColumns,
-                        dataDictionaryBanner: (dataDictionaryBanner && displayDataDictionaryTab),
-                        datasetTableControls: !disableTableControls
-                      }}>
-                        <DataTableStateWrapper />
-                      </DataTableContext.Provider>
-                    </TabPanel>
-                  )}
+                  <TabPanel
+                    id={'data-table'}
+                    tab={
+                      <span className="ds-u-color--primary">
+                        <SearchItemIcon id="data-table" />
+                        Data Table
+                      </span>
+                    }
+                    className={borderlessTabs ? 'ds-u-border--0 ds-u-padding-x--0' : ''}
+                  >
+                    {getFormatType(distribution) === "csv"
+                      ? (
+                        <DataTableContext.Provider value={{
+                          id: id,
+                          resource: resource,
+                          distribution: distribution,
+                          rootUrl: rootUrl,
+                          customColumns: customColumns,
+                          dataDictionaryBanner: (dataDictionaryBanner && displayDataDictionaryTab),
+                          datasetTableControls: !disableTableControls
+                        }}>
+                          <DataTableStateWrapper />
+                        </DataTableContext.Provider>
+                      ) : (
+                        <p>There is no Data Table associated with this dataset. Data Tables will only display for CSV files</p>
+                      )
+                    }
+                  </TabPanel>
                   <TabPanel
                     id={'overview'}
                     tab={
@@ -222,13 +227,17 @@ const Dataset = ({
                       }
                       className={borderlessTabs ? 'ds-u-border--0 ds-u-padding-x--0' : ''}
                     >
-                      {displayDataDictionaryTab && <DataDictionary
-                        datasetSitewideDictionary={datasetSitewideDictionary}
-                        datasetDictionaryEndpoint={distribution.data.describedBy}
-                        title={"Data Dictionary"}
-                        csvDownload={dataDictionaryCSV}
-                      />}
-                      {!displayDataDictionaryTab && <p>There is no Data Dictionary associated with this dataset.</p>}
+                      {displayDataDictionaryTab
+                        ? (
+                          <DataDictionary
+                            datasetSitewideDictionary={datasetSitewideDictionary}
+                            datasetDictionaryEndpoint={distribution.data.describedBy}
+                            title={"Data Dictionary"}
+                            csvDownload={dataDictionaryCSV}
+                          />
+                        ) : (
+                          <p>There is no Data Dictionary associated with this dataset.</p>
+                        )}
                     </TabPanel>
                   )}
                   {distribution && distribution.data && (

--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -348,7 +348,7 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
                         if (item.theme.includes(theme))
                           showLargeFile = true;
                       });
-
+ 
                     return (
                       <DatasetSearchListItem
                         key={item.identifier}
@@ -361,6 +361,7 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
                         largeFile={showLargeFile}
                         paginationEnabled={enablePagination}
                         dataDictionaryLinks={dataDictionaryLinks}
+                        distribution={"%Ref:distribution" in item ? item["%Ref:distribution"][0] : {}}
                       />
                     )
                   }) : (


### PR DESCRIPTION
## JIRA Ticket(s)
WCMS-25886: Improve UX for datasets that don't have a datastore table

## What
- Updated Data Table links on dataset search page to display disabled tooltip for datasets that don't have a CSV.
- Updated Data Dictionary links on dataset search page to display disabled tooltip for datasets that don't have a data dictionary.
- Updated unit tests

## How to Test:
1. Set up npm workspace with `cmsds-open-data-components` and the `healthcare` OD repo.
2. Checkout the PR branch (WCMS-25886-improve-ux-for-datasets-with-no-table) within the `cmsds-open-data-components` repo.
3. Spin up the environment.
4. Data Dictionary links are turned off on the dataset search page for data.healthcare. To turn them on to test, open `healthcare/docroot/frontend/src/templates/DatasetSearchPage/index.jsx` and add the `dataDictionaryLinks={true}` prop to the `DatasetSearch` component.
5. Navigate to the dataset search page (http://localhost:3000/datasets).
6. Scroll about half way down the first page and find a dataset item with disabled (greyed out) Data Table and Data Dictionary links. ("QHP Landscape Instructions PY2025 Medical SHOP" for example).
7. Confirm that the links are grey in color and when you hover/focus the links, you can not activate the link and a tooltip displays.
    7.a. Data Table tooltips should read, "There is no Data Table associated with this dataset. Data Tables will only display for CSV files.".
    7.b. Data Dictionary tooltips should read, "There is no Data Dictionary associated with this dataset.".
8. Click the Overview link for the dataset.
9. On the dataset page:
    9.a. The Data Table tab should be visible and when selected, show text that reads, "There is no Data Table associated with this dataset. Data Tables will only display for CSV files.".
    9.b. The Data Dictionary tab should be visible and when selected, show text that reads, "There is no Data Dictionary associated with this dataset.".
10. In terminal, run `npm run test`. All unit tests should pass.
11. Done.