### PR TITLE
WCMS-26069: Add box-shadow style to the main nav submenu containers

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/SubMenu/submenu.scss
+++ b/src/components/SubMenu/submenu.scss
@@ -1,6 +1,7 @@
 .dkan-c-site-menu--sub-menu {
   list-style: none;
   display: none;
+  box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
 }
 
 .dkan-c-nav-submenu {


### PR DESCRIPTION
## JIRA Ticket(s)
WCMS-26069: Add box-shadow style to the main nav submenu containers

## What
- Added box-shadow to the navigation dropdowns.

## How to Test:
1. Set up npm workspace with `cmsds-open-data-components` and the `healthcare` repo.
2. Checkout the PR branch (WCMS-26069-add-box-shadow-to-nav-dropdowns) within the `cmsds-open-data-components` repo.
3. Spin up the environment.
4. Navigate to http://localhost:3000.
5. Confirm that the "Topics" and "What's New" dropdown's have a box-shadow.
6. Done.
