### PR TITLE
Resolve screen reader issue on dataset toolbar buttons

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/DataTableToolbar/DataTableToolbar.scss
+++ b/src/components/DataTableToolbar/DataTableToolbar.scss
@@ -31,6 +31,21 @@
   }
 }
 
+@media screen and (max-width: 1023px) {
+  // make button labels hidden on screens smaller than 1024px
+  .dkan-dataset-toolbar-button-label {
+    clip: rect(0, 0, 0, 0);
+    word-wrap: normal;
+    border: 0;
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    position: absolute;
+    width: 1px;
+  }
+  
+}
+
 @media screen and (max-width: 767px) {
   .dkan-data-table-toolbar-controls {
     justify-content: space-between;

--- a/src/components/DisplaySettings/index.test.tsx
+++ b/src/components/DisplaySettings/index.test.tsx
@@ -148,7 +148,7 @@ describe('DisplaySettings', () => {
 
     it('renders the display settings text on large screens', () => {
       renderWithProviders();
-      const displayText = screen.getByTestId('tooltip').querySelector('.ds-u-display--none.ds-u-lg-display--inline-block');
+      const displayText = screen.getByTestId('tooltip').querySelector('.dkan-dataset-toolbar-button-label');
       expect(displayText).toHaveTextContent('Display Settings');
     });
   });

--- a/src/components/DisplaySettings/index.tsx
+++ b/src/components/DisplaySettings/index.tsx
@@ -94,7 +94,7 @@ const DisplaySettings: React.FC = () => {
         }
       >
         <i className="far fa-sliders-h ds-u-margin-right--1"></i>
-        <span className="ds-u-display--none ds-u-lg-display--inline-block">Display Settings</span>
+        <span className="dkan-dataset-toolbar-button-label">Display Settings</span>
         <i className="fa fa-chevron-down ds-u-margin-left--1 ds-u-font-weight--bold"></i>
         <i className="fa fa-chevron-up ds-u-margin-left--1 ds-u-font-weight--bold"></i>
       </Tooltip>

--- a/src/components/FilterDataset/index.tsx
+++ b/src/components/FilterDataset/index.tsx
@@ -216,7 +216,7 @@ const FilterDataset: React.FC = () => {
           >
             <i className="fa fa-filter ds-u-margin-right--1"></i>
             <span>
-              <span className="ds-u-display--none ds-u-lg-display--inline-block">
+              <span className="dkan-dataset-toolbar-button-label">
                 {conditions.length > 0
                   ? `Edit Filters`
                   : 'Filter Dataset'

--- a/src/components/FullScreenDataTable/index.tsx
+++ b/src/components/FullScreenDataTable/index.tsx
@@ -25,7 +25,7 @@ const FullScreenDataTable: React.FC<FullScreenDataTableProps> = ({ isModal }) =>
         }}
       >
         <i className={`far ${modalOpen ? 'fa-compress' : 'fa-expand'} ds-u-margin-right--1`}></i>
-        <span className="ds-u-display--none ds-u-lg-display--inline-block">
+        <span className="dkan-dataset-toolbar-button-label">
           {modalOpen ? "Exit Full Screen" : "Full Screen"}
         </span>
       </button>

--- a/src/components/ManageColumns/ManageColumns.jsx
+++ b/src/components/ManageColumns/ManageColumns.jsx
@@ -133,7 +133,7 @@ const ManageColumns = ({
       >
         <i className="fa fa-columns ds-u-margin-right--1"></i>
         <span>
-          <span className="ds-u-display--none ds-u-lg-display--inline-block">Manage Columns</span>
+          <span className="dkan-dataset-toolbar-button-label">Manage Columns</span>
           {hiddenColumns ? ` (${hiddenColumns})` : ''}
         </span>
       </button>


### PR DESCRIPTION
Resolve an issues where toolbar button label text is missing in mobile and tablet views

Testing:

- Checkout branch in workspaces with a downstream data site
- Open dev tools and change screen size in responsive view to be less than 1024px
- Open voice over on MacOS or another screen reader if using a different operating system
- Tab through the dataset toolbar buttons and verify that the screen reader reads the button labels for 'Filter Dataset', 'Manage Columns', 'Display Settings', and 'Full Screen'