### PR TITLE
Update DatasetDescription customDescription prop to accept react component

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.0.2",
+  "version": "4.0.4",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/DatasetDescription/index.tsx
+++ b/src/components/DatasetDescription/index.tsx
@@ -2,16 +2,20 @@ import React, { useEffect, useState } from 'react';
 import DOMPurify from 'dompurify';
 import { DatasetDescriptionType } from '../../types/dataset';
 
+type DescriptionContent = string | React.ReactNode;
+
 const DatasetDescription = (
   {distribution, dataset, resource, customDescription, updateAriaLive} : DatasetDescriptionType
 ) => {
-  const [description, setDescription] = useState("");
+  const [description, setDescription] = useState<DescriptionContent>("");
 
   if(!distribution && !dataset?.identifier) {
     return null;
   }
+
   useEffect(() => {
-    let newDescription = '';
+    let newDescription: DescriptionContent = '';
+
     if (customDescription) {
       newDescription = customDescription(dataset, distribution, resource);
     } else {
@@ -21,18 +25,25 @@ const DatasetDescription = (
         newDescription = dataset.description;
       }
     }
-    if (description !== newDescription && updateAriaLive) {
+
+    if (typeof newDescription === "string" && description !== newDescription && updateAriaLive) {
       updateAriaLive(newDescription);
     }
+
     setDescription(newDescription);
   }, [resource, distribution, dataset, customDescription]);
   
   return (
     <div className={'ds-u-measure--wide ds-u-margin-bottom--7'}>
-      <div 
-        className="ds-u-margin-top--0 dc-c-metadata-description"
-        dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(description) }}
-      />
+      <div className="ds-u-margin-top--0 dc-c-metadata-description">
+        {typeof description === "string" ? (
+          <div
+            dangerouslySetInnerHTML={{ __html: DOMPurify.sanitize(description) }}
+          />
+        ) : (
+          description
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## JIRA Ticket(s)
WCMS-26034: [ECP] Update Dataset page to guide users to Map

## What
- Updated DatasetDescription customDescription prop to accept a react component.

## How to Test:
1. In your local data.healthcare repo, install `@civicactions/cmsds-open-data-components@4.0.4-alpha.0`.
2. Spin up the environment.
3. Navigate to http://localhost:3000/rolling-draft-list.
4. Confirm that there is a blue information alert in the dataset description with the content: "To better understand provider distribution and access within a specific area, visit the Rolling Draft List Map Tool."
5. Navigate to a few other random datasets and confirm that the dataset descriptions display as expected.
6. Done.
