### PR TITLE
WCMS-26491: Dataset "Share" button should convey that it opens a dialog

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -136,5 +136,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: January 23, 2026*  
+*Last updated: January 27, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/src/components/Datatable/Datatable.jsx
+++ b/src/components/Datatable/Datatable.jsx
@@ -152,6 +152,7 @@ const DataTable = ({
                   0,
                   5
                 ]}
+                aria-haspopup="dialog"
                 placement="bottom-start"
                 maxWidth="320px"
                 title={


### PR DESCRIPTION
## JIRA Ticket(s)
WCMS-26491: Dataset "Share" button should convey that it opens a dialog

## What
- Added aria-haspopup attribute to share button.

## How to Test:
1. In your local data.healthcare (or data.medicaid, etc) repo, install `@civicactions/cmsds-open-data-components@4.0.13-alpha.18`.
2. Spin up the environment.
3. Navigate to any dataset page.
4. Inspect the "Share" button.
5. Verify that you see an 'aria-haspopup="dialog"' attribute on the button element.
6. Done.