### PR TITLE
Remove Duplicate Row Limit Notices on API page

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: April 10, 2026*  
+*Last updated: April 13, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.2",
+  "version": "4.1.3-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.1.2",
+      "version": "4.1.3-alpha.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0-alpha.1",
@@ -17,7 +17,7 @@
         "@popperjs/core": "^2.11.6",
         "@tanstack/react-query": "^5.14.1",
         "@tanstack/react-table": "^8.7.9",
-        "axios": "^1.13.2",
+        "axios": "^1.15.0",
         "dompurify": "^3.0.5",
         "immutable": "^5.1.5",
         "lodash.truncate": "^4.4.2",
@@ -11347,12 +11347,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.4",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
-        "proxy-from-env": "^1.1.0"
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -17845,8 +17847,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.2",
+  "version": "4.1.3",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",
@@ -33,7 +33,7 @@
     "@popperjs/core": "^2.11.6",
     "@tanstack/react-query": "^5.14.1",
     "@tanstack/react-table": "^8.7.9",
-    "axios": "^1.13.2",
+    "axios": "^1.15.0",
     "dompurify": "^3.0.5",
     "immutable": "^5.1.5",
     "lodash.truncate": "^4.4.2",

--- a/src/components/DatasetSearchListItem/index.tsx
+++ b/src/components/DatasetSearchListItem/index.tsx
@@ -171,7 +171,7 @@ const DatasetSearchListItem = (props: SearchItemProps) => {
     )
   }
 
-  const dateOptions = updateDateMonthYearOnly ? {
+  const dateOptions: Intl.DateTimeFormatOptions | undefined = updateDateMonthYearOnly ? {
       year: 'numeric',
       month: 'long',
       day: undefined,

--- a/src/templates/APIPage/APIPage.tsx
+++ b/src/templates/APIPage/APIPage.tsx
@@ -3,7 +3,6 @@ import qs from 'qs';
 import SwaggerUI from 'swagger-ui-react';
 import SpanOpenAPIVersion from '../../utilities/ApiDocsSwaggerUIPlugin/SpanOpenAPIVersion';
 import SpanVersionStamp from '../../utilities/ApiDocsSwaggerUIPlugin/SpanVersionStamp';
-import ApiRowLimitNotice from '../../components/ApiRowLimitNotice';
 import ApiDocsSwaggerUIPlugin, { ApiDocsSwaggerUIPluginProps } from '../../utilities/ApiDocsSwaggerUIPlugin';
 import 'swagger-ui-react/swagger-ui.css';
 import './swagger-ui-overrides.scss';
@@ -25,7 +24,6 @@ const APIPage: React.FC<APIPageProps> = ({ hideAuth = true, rootUrl, showRowLimi
 
   return (
     <>
-      {showRowLimitNotice && <ApiRowLimitNotice />}
       <section className="ds-l-container ds-u-padding--0 ds-u-margin-top--5">
         <SwaggerUI
           url={`${rootUrl}${qs.stringify(acaToParams(params, ACA), { addQueryPrefix: true })}`}

--- a/src/templates/APIPage/swagger-ui-overrides.scss
+++ b/src/templates/APIPage/swagger-ui-overrides.scss
@@ -14,6 +14,18 @@ This document provides overrides to Swagger UI, fixing accessibility issues.
   --su-color--red-light: rgba(211, 0, 0, .1);
   --su-color--red: rgb(211, 0, 0);
 }
+// Reset container styles when APIPage is nested inside another ds-l-container
+// (e.g., when rendered inside SidebarPage)
+.ds-l-container section.ds-l-container:has(.swagger-ui) {
+  max-width: none;
+  padding-inline: 0;
+  margin-inline: 0;
+}
+.ds-l-container #api-docs-swagger-ui-plugin.ds-l-container {
+  max-width: none;
+  padding-inline: 0;
+  margin-inline: 0;
+}
 // State  `.swagger-ui` twice to include specificity and avoid multiple `!important` statements;
 .swagger-ui.swagger-ui {
   font-family: inherit;

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -162,7 +162,7 @@ const Dataset = ({
 
   const date = {modified: dataset.modified, released: dataset.released, refresh: dataset.nextUpdateDate};
 
-  const dateOptions = updateDateMonthYearOnly ? {
+  const dateOptions: Intl.DateTimeFormatOptions | undefined = updateDateMonthYearOnly ? {
       year: 'numeric',
       month: 'long',
       day: undefined,


### PR DESCRIPTION
Testing steps:

- Setup this branch with workspaces or install the `4.1.3-alpha.2` alpha release on a data site
- Navigate to the sitewide API page (/about/api or /api depending on site)
- data.medicaid is recommended for testing since it has the row limit notice already enabled 
- Confirm the row limit notice only show up once on the page
- Confirm the extra padding that was there previously has been removed

Current version of the page:
<img width="1283" height="691" alt="Screenshot 2026-04-13 at 10 54 56 AM" src="https://github.com/user-attachments/assets/2ba2807e-ff84-4b1f-9053-a6cbb1d26a63" />


What the page should look like after the fix:
<img width="1257" height="796" alt="Screenshot 2026-04-14 at 8 57 11 AM" src="https://github.com/user-attachments/assets/e1c8f7de-c607-4169-83c1-117246bd7053" />

