### PR TITLE
Change Orientation of Dropdown Icon

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -65,7 +65,7 @@ This document provides a comprehensive inventory of all components, services, te
 | Component | [SearchModal](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SearchModal) | ❌ Internal | ✅ Has Story | ❌ No Tests |
 | Component | [SidebarNavigation](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SidebarNavigation) | ✅ Public | ✅ Has Story | ❌ No Tests |
 | Component | [SitewideDataDictionaryTable](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SitewideDataDictionaryTable) | ❌ Internal | ✅ Has Story | ❌ No Tests |
-| Component | [SubMenu](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SubMenu) | ✅ Public | ❌ No Story | ❌ No Tests |
+| Component | [SubMenu](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SubMenu) | ✅ Public | ✅ Has Story | ✅ Has Tests |
 | Component | [SubMenuStaticList](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SubMenuStaticList) | ❌ Internal | ❌ No Story | ❌ No Tests |
 | Component | [TopicInformation](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/TopicInformation) | ❌ Internal | ✅ Has Story | ✅ Has Tests |
 | Component | [TransformedDate](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/TransformedDate) | ✅ Public | ✅ Has Story | ❌ No Tests |
@@ -123,11 +123,11 @@ This document provides a comprehensive inventory of all components, services, te
 
 | Category | Total | With Stories | With Tests | With Both | With Neither |
 |----------|-------|--------------|------------|-----------|--------------|
-| Components | 64 | 39 (61%) | 26 (41%) | 14 (22%) | 13 (20%) |
+| Components | 64 | 40 (63%) | 27 (42%) | 15 (23%) | 12 (19%) |
 | Templates | 11 | 10 (91%) | 3 (27%) | 3 (27%) | 1 (9%) |
 | Services/Hooks/Contexts | 9 | 0 (0%) | 0 (0%) | 0 (0%) | 9 (100%) |
 | Utilities/Types/Assets | 12 | 0 (0%) | 0 (0%) | 0 (0%) | 12 (100%) |
-| **Project Total** | **96** | **49 (51%)** | **29 (30%)** | **17 (18%)** | **35 (36%)** |
+| **Project Total** | **96** | **50 (52%)** | **30 (31%)** | **18 (19%)** | **34 (35%)** |
 
 ---
 
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: April 13, 2026*  
+*Last updated: April 20, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.3-alpha.1",
+  "version": "4.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.1.3-alpha.1",
+      "version": "4.1.4",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.3",
+  "version": "4.1.4",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/HeaderNav/index.tsx
+++ b/src/components/HeaderNav/index.tsx
@@ -3,7 +3,7 @@ import { NavLink } from 'react-router-dom';
 import { Button, CloseIconThin } from '@cmsgov/design-system';
 import HeaderContext from '../../templates/Header/HeaderContext';
 import SubMenu from '../SubMenu';
-import { NavLinkArray } from '../../templates/Header';
+import { NavLinkArray } from '../../types/misc';
 import HeaderSearch from '../HeaderSearch';
 import './header-nav.scss';
 

--- a/src/components/SubMenu/SubMenu.stories.tsx
+++ b/src/components/SubMenu/SubMenu.stories.tsx
@@ -77,7 +77,9 @@ type Story = StoryObj<typeof SubMenu>;
 export const Default: Story = {
   args: {
     link: {
+      id: 'resources',
       label: 'Resources',
+      url: '/resources',
       submenu: [
         { id: 'datasets', label: 'Datasets', url: '/datasets' },
         { id: 'api', label: 'API', url: '/api' },
@@ -100,7 +102,9 @@ export const Default: Story = {
 export const WithIcons: Story = {
   args: {
     link: {
+      id: 'explore',
       label: 'Explore',
+      url: '/explore',
       submenu: [
         { id: 'datasets', label: 'Datasets', url: '/datasets', icon: <SimpleIcon /> },
         { id: 'topics', label: 'Topics', url: '/topics', icon: <SimpleIcon /> },
@@ -123,7 +127,9 @@ export const WithIcons: Story = {
 export const WithExternalLinks: Story = {
   args: {
     link: {
+      id: 'external',
       label: 'External',
+      url: '/external',
       submenu: [
         { id: 'docs', label: 'Documentation', url: 'https://example.com/docs', external: true },
         { id: 'support', label: 'Support', url: 'https://example.com/support', external: true },
@@ -145,7 +151,9 @@ export const WithExternalLinks: Story = {
 export const UnwrappedLabel: Story = {
   args: {
     link: {
+      id: 'menu',
       label: 'Menu',
+      url: '/menu',
       submenu: [
         { id: 'item1', label: 'Item One', url: '/one' },
         { id: 'item2', label: 'Item Two', url: '/two' },
@@ -167,7 +175,9 @@ export const UnwrappedLabel: Story = {
 export const OnDarkBackground: Story = {
   args: {
     link: {
+      id: 'navigation',
       label: 'Navigation',
+      url: '/navigation',
       submenu: [
         { id: 'home', label: 'Home', url: '/' },
         { id: 'data', label: 'Data', url: '/data' },

--- a/src/components/SubMenu/SubMenu.stories.tsx
+++ b/src/components/SubMenu/SubMenu.stories.tsx
@@ -1,0 +1,198 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import SubMenu from './index';
+import HeaderContext from '../../templates/Header/HeaderContext';
+import { MemoryRouter } from 'react-router-dom';
+
+const mockHeaderContext = {
+  mobileMenuOpen: false,
+  setMobileMenuOpen: () => {},
+  menuRef: null,
+  isMobile: false,
+  onDark: false,
+};
+
+const SimpleIcon = () => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 16 16"
+    width="16"
+    height="16"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <circle cx="8" cy="8" r="6" />
+  </svg>
+);
+
+const meta: Meta<typeof SubMenu> = {
+  title: 'Components/SubMenu',
+  component: SubMenu,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component: `
+The SubMenu component renders a navigation item with an expandable dropdown menu. It supports static submenu lists (array of link objects) and closes on outside click or focus loss.
+        `,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <HeaderContext.Provider value={mockHeaderContext}>
+          <nav>
+            <ul style={{ listStyle: 'none', padding: 0 }}>
+              <Story />
+            </ul>
+          </nav>
+        </HeaderContext.Provider>
+      </MemoryRouter>
+    ),
+  ],
+  argTypes: {
+    link: {
+      control: 'object',
+      description: 'Object containing label and submenu configuration.',
+    },
+    linkClasses: {
+      control: 'text',
+      description: 'CSS classes for the main menu button.',
+    },
+    subLinkClasses: {
+      control: 'text',
+      description: 'CSS classes for submenu links.',
+    },
+    wrapLabel: {
+      control: 'boolean',
+      description: 'Whether to wrap the button label in a span.',
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SubMenu>;
+
+export const Default: Story = {
+  args: {
+    link: {
+      label: 'Resources',
+      submenu: [
+        { id: 'datasets', label: 'Datasets', url: '/datasets' },
+        { id: 'api', label: 'API', url: '/api' },
+        { id: 'about', label: 'About', url: '/about' },
+      ],
+    },
+    linkClasses: '',
+    subLinkClasses: '',
+    wrapLabel: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A submenu with a static list of internal links.',
+      },
+    },
+  },
+};
+
+export const WithIcons: Story = {
+  args: {
+    link: {
+      label: 'Explore',
+      submenu: [
+        { id: 'datasets', label: 'Datasets', url: '/datasets', icon: <SimpleIcon /> },
+        { id: 'topics', label: 'Topics', url: '/topics', icon: <SimpleIcon /> },
+        { id: 'publishers', label: 'Publishers', url: '/publishers', icon: <SimpleIcon /> },
+      ],
+    },
+    linkClasses: '',
+    subLinkClasses: '',
+    wrapLabel: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A submenu with icons alongside each link. Uses inline SVG icons as replacements for Font Awesome Pro icons.',
+      },
+    },
+  },
+};
+
+export const WithExternalLinks: Story = {
+  args: {
+    link: {
+      label: 'External',
+      submenu: [
+        { id: 'docs', label: 'Documentation', url: 'https://example.com/docs', external: true },
+        { id: 'support', label: 'Support', url: 'https://example.com/support', external: true },
+      ],
+    },
+    linkClasses: '',
+    subLinkClasses: '',
+    wrapLabel: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A submenu with external links rendered as standard anchor tags.',
+      },
+    },
+  },
+};
+
+export const UnwrappedLabel: Story = {
+  args: {
+    link: {
+      label: 'Menu',
+      submenu: [
+        { id: 'item1', label: 'Item One', url: '/one' },
+        { id: 'item2', label: 'Item Two', url: '/two' },
+      ],
+    },
+    linkClasses: '',
+    subLinkClasses: '',
+    wrapLabel: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'A submenu with wrapLabel set to false, rendering the button label as plain text.',
+      },
+    },
+  },
+};
+
+export const OnDarkBackground: Story = {
+  args: {
+    link: {
+      label: 'Navigation',
+      submenu: [
+        { id: 'home', label: 'Home', url: '/' },
+        { id: 'data', label: 'Data', url: '/data' },
+      ],
+    },
+    linkClasses: '',
+    subLinkClasses: '',
+    wrapLabel: true,
+  },
+  decorators: [
+    (Story) => (
+      <HeaderContext.Provider value={{ ...mockHeaderContext, onDark: true }}>
+        <nav style={{ backgroundColor: '#1a1a1a', padding: '1rem' }}>
+          <ul style={{ listStyle: 'none', padding: 0 }}>
+            <Story />
+          </ul>
+        </nav>
+      </HeaderContext.Provider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        story: 'A submenu rendered on a dark background using the onDark header context.',
+      },
+    },
+  },
+};

--- a/src/components/SubMenu/index.jsx
+++ b/src/components/SubMenu/index.jsx
@@ -70,7 +70,7 @@ const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }) => {
         }}
       >
         {innerHtml}
-        <ArrowIcon className="ds-u-margin-left--1" direction={isExpanded ? "down" : "right"} />
+        <ArrowIcon className="ds-u-margin-left--1" direction={isExpanded ? "up" : "down"} />
       </Button>
       {submenuBlock}
     </li>

--- a/src/components/SubMenu/index.tsx
+++ b/src/components/SubMenu/index.tsx
@@ -1,29 +1,38 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { ReactElement, ReactNode, useEffect, useState, useRef } from 'react';
 import { Button, ArrowIcon } from '@cmsgov/design-system';
 import HeaderContext from '../../templates/Header/HeaderContext';
 import DatasetListSubmenu from '../DatasetListSubmenu';
+import { NavLinkArray } from '../../types/misc';
+import { DatasetSubmenuListProps } from '../../types/search';
 
 import './submenu.scss';
 import SubMenuStaticList from '../SubMenuStaticList';
 
-const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }) => {
+export type SubMenuProps = {
+  link: NavLinkArray;
+  linkClasses?: string;
+  subLinkClasses?: string;
+  wrapLabel?: boolean;
+};
+
+const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }: SubMenuProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const headerContext = React.useContext(HeaderContext);
-  const innerHtml = wrapLabel ? <span>{link.label}</span> : link.label;
-  const menu = useRef();
+  const innerHtml: ReactNode = wrapLabel ? <span>{link.label}</span> : link.label;
+  const menu = useRef<HTMLLIElement>(null);
   useEffect(() => {
-    let currentMenu = null;
+    let currentMenu: HTMLLIElement | null = null;
     if (menu.current) {
       currentMenu = menu.current;
     }
 
-    function handleClickOutside(event) {
-      if (currentMenu && !currentMenu.contains(event.target)) {
+    function handleClickOutside(event: MouseEvent) {
+      if (currentMenu && !currentMenu.contains(event.target as Node)) {
         setIsExpanded(false);
       }
     }
-    function handleFocusOut(event) {
-      if (currentMenu && !currentMenu.contains(event.relatedTarget)) {
+    function handleFocusOut(event: FocusEvent) {
+      if (currentMenu && !currentMenu.contains(event.relatedTarget as Node)) {
         setIsExpanded(false);
       }
     }
@@ -37,7 +46,7 @@ const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }) => {
     };
   }, [isExpanded]);
 
-  let submenuBlock;
+  let submenuBlock: ReactNode;
 
    if(link.submenu) {
     if (Array.isArray(link.submenu)) {
@@ -46,8 +55,8 @@ const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }) => {
         subLinkClasses={subLinkClasses}
         setIsExpanded={setIsExpanded}
       />;
-    } else if (React.isValidElement(link.submenu) ) {
-      const {rootUrl, location} = link.submenu.props;
+    } else if (React.isValidElement(link.submenu)) {
+      const { rootUrl, location } = (link.submenu as ReactElement<DatasetSubmenuListProps>).props;
       submenuBlock = <DatasetListSubmenu
         location={location}
         rootUrl={rootUrl}
@@ -64,7 +73,7 @@ const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }) => {
         className={`${linkClasses}`}
         aria-haspopup="true"
         aria-expanded={isExpanded}
-        onClick={(e) => {
+        onClick={(e: React.MouseEvent) => {
           e.preventDefault();
           setIsExpanded(!isExpanded);
         }}

--- a/src/components/SubMenu/submenu.test.tsx
+++ b/src/components/SubMenu/submenu.test.tsx
@@ -5,12 +5,18 @@ import '@testing-library/jest-dom';
 import { MemoryRouter } from 'react-router-dom';
 import HeaderContext from '../../templates/Header/HeaderContext';
 import SubMenu from './index';
+import { NavLinkArray } from '../../types/misc';
+
+type MockSubMenuStaticListProps = {
+  submenuArray: NavLinkArray[];
+  subLinkClasses: string;
+};
 
 jest.mock('../SubMenuStaticList', () => {
-  return function MockSubMenuStaticList({ submenuArray, subLinkClasses }: any) {
+  return function MockSubMenuStaticList({ submenuArray, subLinkClasses }: MockSubMenuStaticListProps) {
     return (
       <ul data-testid="submenu-list" className="dkan-c-site-menu--sub-menu">
-        {submenuArray.map((item: any) => (
+        {submenuArray.map((item: NavLinkArray) => (
           <li key={item.id}>
             <a href={item.url} className={subLinkClasses}>
               {item.icon ?? null}
@@ -37,16 +43,20 @@ const mockHeaderContext = {
   onDark: false,
 };
 
-const staticSubmenuLink = {
+const staticSubmenuLink: NavLinkArray = {
+  id: 'resources',
   label: 'Resources',
+  url: '/resources',
   submenu: [
     { id: 'datasets', label: 'Datasets', url: '/datasets' },
     { id: 'api', label: 'API', url: '/api' },
   ],
 };
 
-const externalSubmenuLink = {
+const externalSubmenuLink: NavLinkArray = {
+  id: 'external',
   label: 'External',
+  url: '/external',
   submenu: [
     { id: 'docs', label: 'Documentation', url: 'https://example.com/docs', external: true },
   ],

--- a/src/components/SubMenu/submenu.test.tsx
+++ b/src/components/SubMenu/submenu.test.tsx
@@ -1,0 +1,180 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+import { MemoryRouter } from 'react-router-dom';
+import HeaderContext from '../../templates/Header/HeaderContext';
+import SubMenu from './index';
+
+jest.mock('../SubMenuStaticList', () => {
+  return function MockSubMenuStaticList({ submenuArray, subLinkClasses }: any) {
+    return (
+      <ul data-testid="submenu-list" className="dkan-c-site-menu--sub-menu">
+        {submenuArray.map((item: any) => (
+          <li key={item.id}>
+            <a href={item.url} className={subLinkClasses}>
+              {item.icon ?? null}
+              <span>{item.label}</span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    );
+  };
+});
+
+jest.mock('../DatasetListSubmenu', () => {
+  return function MockDatasetListSubmenu() {
+    return <ul data-testid="dataset-submenu" />;
+  };
+});
+
+const mockHeaderContext = {
+  mobileMenuOpen: false,
+  setMobileMenuOpen: () => {},
+  menuRef: null,
+  isMobile: false,
+  onDark: false,
+};
+
+const staticSubmenuLink = {
+  label: 'Resources',
+  submenu: [
+    { id: 'datasets', label: 'Datasets', url: '/datasets' },
+    { id: 'api', label: 'API', url: '/api' },
+  ],
+};
+
+const externalSubmenuLink = {
+  label: 'External',
+  submenu: [
+    { id: 'docs', label: 'Documentation', url: 'https://example.com/docs', external: true },
+  ],
+};
+
+const renderSubMenu = (props = {}) => {
+  return render(
+    <MemoryRouter>
+      <HeaderContext.Provider value={mockHeaderContext}>
+        <nav>
+          <ul>
+            <SubMenu
+              link={staticSubmenuLink}
+              linkClasses=""
+              subLinkClasses=""
+              wrapLabel={true}
+              {...props}
+            />
+          </ul>
+        </nav>
+      </HeaderContext.Provider>
+    </MemoryRouter>
+  );
+};
+
+describe('<SubMenu />', () => {
+  it('renders the menu button with the link label', () => {
+    renderSubMenu();
+    expect(screen.getByRole('button', { name: /Resources/i })).toBeInTheDocument();
+  });
+
+  it('sets aria-haspopup on the button', () => {
+    renderSubMenu();
+    expect(screen.getByRole('button', { name: /Resources/i })).toHaveAttribute('aria-haspopup', 'true');
+  });
+
+  it('starts with aria-expanded set to false', () => {
+    renderSubMenu();
+    expect(screen.getByRole('button', { name: /Resources/i })).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands the submenu on click', async () => {
+    renderSubMenu();
+    const button = screen.getByRole('button', { name: /Resources/i });
+
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('collapses the submenu on second click', async () => {
+    renderSubMenu();
+    const button = screen.getByRole('button', { name: /Resources/i });
+
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('adds the open class when expanded', async () => {
+    renderSubMenu();
+    const button = screen.getByRole('button', { name: /Resources/i });
+    const listItem = button.closest('li');
+
+    expect(listItem).not.toHaveClass('open');
+
+    await userEvent.click(button);
+    expect(listItem).toHaveClass('open');
+  });
+
+  it('renders static submenu links', async () => {
+    renderSubMenu();
+    await userEvent.click(screen.getByRole('button', { name: /Resources/i }));
+
+    expect(screen.getByText('Datasets')).toBeInTheDocument();
+    expect(screen.getByText('API')).toBeInTheDocument();
+  });
+
+  it('renders external links as anchor tags', async () => {
+    renderSubMenu({ link: externalSubmenuLink });
+    await userEvent.click(screen.getByRole('button', { name: /External/i }));
+
+    const link = screen.getByText('Documentation').closest('a');
+    expect(link).toHaveAttribute('href', 'https://example.com/docs');
+  });
+
+  it('closes the submenu when clicking outside', async () => {
+    renderSubMenu();
+    const button = screen.getByRole('button', { name: /Resources/i });
+
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.mouseDown(document.body);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('wraps the label in a span when wrapLabel is true', () => {
+    renderSubMenu({ wrapLabel: true });
+    const button = screen.getByRole('button', { name: /Resources/i });
+    expect(button.querySelector('span')).toBeInTheDocument();
+  });
+
+  it('does not wrap the label in a span when wrapLabel is false', () => {
+    renderSubMenu({ wrapLabel: false });
+    const button = screen.getByRole('button', { name: /Resources/i });
+    const spans = button.querySelectorAll('span');
+    // The only span may be from ArrowIcon; the label text should not be in a span
+    const labelSpan = Array.from(spans).find((s) => s.textContent === 'Resources');
+    expect(labelSpan).toBeUndefined();
+  });
+
+  it('renders submenu items with icons when provided', async () => {
+    const linkWithIcons = {
+      label: 'Explore',
+      submenu: [
+        {
+          id: 'datasets',
+          label: 'Datasets',
+          url: '/datasets',
+          icon: <svg data-testid="submenu-icon" />,
+        },
+      ],
+    };
+    renderSubMenu({ link: linkWithIcons });
+    await userEvent.click(screen.getByRole('button', { name: /Explore/i }));
+
+    expect(screen.getByTestId('submenu-icon')).toBeInTheDocument();
+  });
+});

--- a/src/templates/Header/Header.stories.tsx
+++ b/src/templates/Header/Header.stories.tsx
@@ -7,8 +7,7 @@ import HeaderNav from '../../components/HeaderNav';
 import HeaderSearch from '../../components/HeaderSearch';
 import MobileMenuButton from '../../components/MobileMenuButton';
 import cmsLogo from '../../assets/images/CMSgov@2x-white-O.png';
-import type { NavLinkArray } from './index';
-import type { OrgType } from '../../types/misc';
+import type { NavLinkArray, OrgType } from '../../types/misc';
 
 const meta: Meta<typeof Header> = {
   title: 'Templates/Header',

--- a/src/templates/Header/index.tsx
+++ b/src/templates/Header/index.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, ReactNode, ReactElement, useRef } from 'react';
+import React, { useEffect, ReactElement, ReactNode, useRef } from 'react';
 import { useMediaQuery } from 'react-responsive'
 import CMSTopNav from '../../components/CMSTopNav';
 import HeaderContext from './HeaderContext';
@@ -11,16 +11,6 @@ type HeaderProps = {
   mobileMaxWidth?: number;
   onDark?: boolean;
 };
-
-export type NavLinkArray = {
-  id: string;
-  label: string;
-  url: string;
-  target?: string;
-  submenu?: NavLinkArray[];
-  icon?: ReactNode;
-  drupalPage?: boolean;
-}
 
 const Header = (props: HeaderProps) => {
   const { topNav, children, mobileMaxWidth = 768, onDark = false } = props;

--- a/src/types/misc.ts
+++ b/src/types/misc.ts
@@ -1,4 +1,4 @@
-import { ReactNode } from "react"
+import { ReactElement, ReactNode } from "react"
 
 export type FAQItemType = {
   id: string,
@@ -27,5 +27,8 @@ export type NavLinkArray = {
   label: string;
   url: string;
   target?: string;
-  submenu?: NavLinkArray[]
+  submenu?: NavLinkArray[] | ReactElement;
+  icon?: ReactNode;
+  external?: boolean;
+  drupalPage?: boolean;
 }


### PR DESCRIPTION
- Change the orientation of the arrow icons of the submenu dropdowns.
- Convert SubMenu to TypeScript
- Add Submenu Storybook story
- Add Submenu unit test

**testing:**
- Install the 4.1.4-alpha.0 upstream on one of the data sites
- visit the home page and confirm the orientation of the arrow icons in the menu 
- the arrow should be pointing downwards when the submenu is closed
- the arrow should be pointing upwards when the submenu is open
- from your local cmsds-opendata-components repo, run `npm run storybook`
- confirm a new story has been added for submenu
- run `npm run test` and confirm tests pass 