### PR TITLE
update default header syles to match the new site header redesigns

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: April 22, 2026*  
+*Last updated: May 5, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.1.5",
+      "version": "4.2.0",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.5",
+  "version": "4.2.0",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/templates/Header/header.scss
+++ b/src/templates/Header/header.scss
@@ -3,10 +3,11 @@
   --main-nav-height: 6.25rem;
   --tag-line--color: #6f757c;
   --tag-line--border-color: #6f757c;
-  --header-nav-icon-link--desktop-width: 240px;
-  --header-nav-icon-link--mobile-width: 240px;
   --header-bg-image: none;
   --header-bg-color: #f7f7f7;
+  --header-mobile-bg-color: var(--color-gray-dark);
+  --header-nav-icon-link--desktop-width: 240px;
+  --header-nav-icon-link--mobile-width: 240px;
   --header-nav-link--color: var(--color-primary);
   --header-nav-search--color: var(--color-primary);
   --mobile-menu-button--color: var(--color-primary);

--- a/src/templates/Header/header.scss
+++ b/src/templates/Header/header.scss
@@ -9,6 +9,7 @@
   --header-nav-icon-link--desktop-width: 240px;
   --header-nav-icon-link--mobile-width: 240px;
   --header-nav-link--color: var(--color-primary);
+  --header-nav-link--mobile-color: var(--color-white);
   --header-nav-search--color: var(--color-primary);
   --mobile-menu-button--color: var(--color-primary);
   --header-submenu--bg-color: var(--color-white);

--- a/src/templates/Header/header.scss
+++ b/src/templates/Header/header.scss
@@ -1,16 +1,17 @@
 :root {
   --mobile-nav-animation-time: 1s;
   --main-nav-height: 6.25rem;
-  --header-bg-color: #{var(--color-primary)};
-  --header-bg-image: linear-gradient(90deg, var(--color-primary-darkest) 10%, var(--color-primary) 90%);
-  --header-nav-link--color: #{var(--color-white)};
-  --header-nav-link--mobile-color: #{var(--color-white)};
-  --header-mobile-bg-color: #{var(--color-gray-dark)};
-  --header-submenu--bg-color: #{var(--color-primary)};
-  --header-submenu--width: 333px; // This oddly specific width ensures that pagers on submenus with dataset listings have 24px width between them. See DatasetListSubmenu.tsx.
-  --header-nav-search--color: #{var(--color-white)};
   --tag-line--color: #6f757c;
   --tag-line--border-color: #6f757c;
+  --header-nav-icon-link--desktop-width: 240px;
+  --header-nav-icon-link--mobile-width: 240px;
+  --header-bg-image: none;
+  --header-bg-color: #f7f7f7;
+  --header-nav-link--color: var(--color-primary);
+  --header-nav-search--color: var(--color-primary);
+  --mobile-menu-button--color: var(--color-primary);
+  --header-submenu--bg-color: var(--color-white);
+  --header-submenu--width: 450px;
 }
 
 .dkan-c-main-navigation > div > div {


### PR DESCRIPTION
This updates the default header styles to match the new unified site header redesign. 

**testing**

- open a terminal and start storybook (npm run storybook)
- navigate to the Header template 
- Confirm new styles have been applied
- Header component "with submenus" story should match screenshot below
<img width="1148" height="292" alt="Screenshot 2026-05-05 at 11 56 56 AM" src="https://github.com/user-attachments/assets/3af40e76-001d-4cc4-a7f1-b669139c2fc5" />
