### PR TITLE
WCMS-28443: Replace the spinner with a message that the data is not available: Part 2

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -29,7 +29,7 @@ This document provides a comprehensive inventory of all components, services, te
 | Component | [DatasetOverviewTab](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatasetOverviewTab) | ❌ Internal | ❌ No Story | ✅ Has Tests |
 | Component | [DatasetSearchFacets](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatasetSearchFacets) | ✅ Public | ✅ Has Story | ✅ Has Tests |
 | Component | [DatasetSearchListItem](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatasetSearchListItem) | ✅ Public | ❌ No Story | ✅ Has Tests |
-| Component | [DatasetTableTab](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatasetTableTab) | ✅ Public (as DatasetTable) | ❌ No Story | ✅ Has Tests |
+| Component | [DatasetTableTab](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatasetTableTab) | ✅ Public (as DatasetTable) | ✅ Has Story | ✅ Has Tests |
 | Component | [Datatable](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/Datatable) | ✅ Public | ❌ No Story | ✅ Has Tests |
 | Component | [DatatableHeader](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DatatableHeader) | ❌ Internal | ✅ Has Story | ✅ Has Tests |
 | Component | [DesktopHeader](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/DesktopHeader) | ❌ Internal | ❌ No Story | ❌ No Tests |
@@ -123,11 +123,11 @@ This document provides a comprehensive inventory of all components, services, te
 
 | Category | Total | With Stories | With Tests | With Both | With Neither |
 |----------|-------|--------------|------------|-----------|--------------|
-| Components | 64 | 40 (63%) | 27 (42%) | 15 (23%) | 12 (19%) |
+| Components | 64 | 41 (64%) | 27 (42%) | 16 (25%) | 12 (19%) |
 | Templates | 11 | 10 (91%) | 3 (27%) | 3 (27%) | 1 (9%) |
 | Services/Hooks/Contexts | 9 | 0 (0%) | 0 (0%) | 0 (0%) | 9 (100%) |
 | Utilities/Types/Assets | 12 | 0 (0%) | 0 (0%) | 0 (0%) | 12 (100%) |
-| **Project Total** | **96** | **50 (52%)** | **30 (31%)** | **18 (19%)** | **34 (35%)** |
+| **Project Total** | **96** | **51 (53%)** | **30 (31%)** | **19 (20%)** | **34 (35%)** |
 
 ---
 
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 12, 2026*  
+*Last updated: May 18, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 6, 2026*  
+*Last updated: May 12, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 19, 2026*  
+*Last updated: May 20, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 18, 2026*  
+*Last updated: May 19, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/__mocks__/mockDistribution.ts
+++ b/__mocks__/mockDistribution.ts
@@ -1,0 +1,26 @@
+import { DistributionType } from '../src/types/dataset';
+
+export const mockDistribution: DistributionType = {
+  "identifier": "32da6993-e045-59e4-823e-a5c2c56c649c",
+  "data": {
+    "@type": "dcat:Distribution",
+    "title": "Registration Completion List for 2016- Present",
+    "description": " ",
+    "format": "csv",
+    "mediaType": "text/csv",
+    "downloadURL": "https://data.healthcare.gov/sites/default/files/uploaded_resources/TBL_RCL_380.csv",
+    "describedBy": "https://data.healthcare.gov/api/1/metastore/schemas/data-dictionary/items/22ad17f4-1b4d-4382-b940-79bddc8bb610",
+    "describedByType": "application/vnd.tableschema+json",
+    "%Ref:downloadURL": [{
+      "identifier": "95e89ec51666a390f472c018137db2d5__1779112050__source",
+      "data": {
+        "filePath": "https://h-o.st/sites/default/files/uploaded_resources/TBL_RCL_380.csv",
+        "identifier": "95e89ec51666a390f472c018137db2d5",
+        "mimeType": "text/csv",
+        "perspective": "source",
+        "version": "1779112050",
+        "checksum": null
+      }
+    }]
+  }
+}

--- a/__mocks__/mockResource.ts
+++ b/__mocks__/mockResource.ts
@@ -1,0 +1,293 @@
+import { ResourceType } from '../src/types/dataset';
+
+export const mockResource: ResourceType = {
+  "loading": false,
+  "error": null,
+  "values": [{
+      "npn": "2037949",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/21/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "623713",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "12/09/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "12/11/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "2609791",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/09/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "10/09/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "16418663",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/28/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "6568550",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "",
+      "individual_marketplace_end_date": "",
+      "shop_registration_completion_date": "11/17/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "1181190",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/25/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "10/25/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "1676828",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "11/04/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "1859013",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/24/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "1340406",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "11/23/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "3529875",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/17/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "09/17/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "2890054",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/07/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "8403861",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/26/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "10/07/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "6414776",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "11/05/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "11/05/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "5951394",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/07/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "10/11/2016",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "16348936",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/16/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "17329602",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/17/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "17149299",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/20/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "3277763",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/29/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "09/29/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "17337935",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/19/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "2031943",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/28/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "09/28/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "1079939",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/17/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "6051537",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/08/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "543454",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "10/30/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "16264977",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/28/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "09/28/2015",
+      "shop_end_date": "10/31/2016",
+      "npn_valid_current_plan_year_only": "-"
+    },
+    {
+      "npn": "17211901",
+      "applicable_plan_year": "2016",
+      "individual_registration_completion_date": "09/24/2015",
+      "individual_marketplace_end_date": "10/31/2016",
+      "shop_registration_completion_date": "",
+      "shop_end_date": "",
+      "npn_valid_current_plan_year_only": "-"
+    }
+  ],
+  "count": 985342,
+  "columns": [
+    "npn",
+    "applicable_plan_year",
+    "individual_registration_completion_date",
+    "individual_marketplace_end_date",
+    "shop_registration_completion_date",
+    "shop_end_date",
+    "npn_valid_current_plan_year_only"
+  ],
+  "totalRows": 985342,
+  "totalColumns": 7,
+  "limit": 25,
+  "offset": 0,
+  "schema": {
+    "32da6993-e045-59e4-823e-a5c2c56c649c": {
+      "fields": {
+        "npn": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "NPN"
+        },
+        "applicable_plan_year": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "Applicable Plan Year"
+        },
+        "individual_registration_completion_date": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "Individual Registration Completion Date"
+        },
+        "individual_marketplace_end_date": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "Individual Marketplace End Date"
+        },
+        "shop_registration_completion_date": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "Shop Registration Completion Date"
+        },
+        "shop_end_date": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "Shop End Date"
+        },
+        "npn_valid_current_plan_year_only": {
+          "type": "text",
+          "mysql_type": "text",
+          "description": "NPN Valid (Current Plan Year Only)"
+        }
+      }
+    }
+  },
+  "conditions": [],
+  "setLimit": () => {},
+  "setOffset": () => {},
+  "setSort": () => {},
+  "setConditions": () => {},
+  "setResource": () => {},
+}

--- a/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
+++ b/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
@@ -13,14 +13,15 @@ import { ResourceType, DistributionType, ColumnType } from '../../types/dataset'
 // and it causes a lot of TypeScript headaches when trying to manipulate the dataTableContextProviderValue
 // in the stories
 export type MockDataTableContextType = {
-  id: string | null,
-  resource: ResourceType,
-  distribution: DistributionType,
-  rootUrl: string,
-  customColumns: Array<ColumnType>,
-  dataDictionaryBanner: boolean,
-  datasetTableControls: boolean,
-  enableEmptyFilters: boolean
+  id: string | null;
+  resource: ResourceType;
+  distribution: DistributionType;
+  rootUrl: string;
+  customColumns: Array<ColumnType>;
+  dataDictionaryBanner: boolean;
+  datasetTableControls: boolean;
+  enableEmptyFilters: boolean;
+  relativeHomeUrlPrepend: string;
 }
 
 // Mock DataTableContext.Provider value
@@ -39,6 +40,7 @@ const defaultDataTableContextProviderValue: MockDataTableContextType = {
   dataDictionaryBanner: false,
   datasetTableControls: true,
   enableEmptyFilters: false,
+  relativeHomeUrlPrepend: '',
 };
 
 // Mock DataTableActionsContext.Provider value
@@ -84,7 +86,6 @@ const meta: Meta<StoryArgs> = {
     showDisplaySettingsButton: true,
     showFullScreenButton: true,
     showInfoShareContainer: true,
-    errorHomeButtonHref: '/',
     dataTableContextProviderValue: defaultDataTableContextProviderValue,
     dataTableActionsContextProviderValue: defaultDataTableActionsContextProviderValue
   },
@@ -112,7 +113,6 @@ content includes dataset download buttons, data table toolbar component, sharing
   showInfoShareContainer
   showManageColumnsButton
   showTableResults
-  errorHomeButtonHref="/"
 />
         `,
       },
@@ -178,10 +178,6 @@ content includes dataset download buttons, data table toolbar component, sharing
       control: 'boolean',
       description: 'Whether or not to show the text information and "Share" button below data table toolbar.',
     },
-    errorHomeButtonHref: {
-      control: 'text',
-      description: 'Href value for the "Back to home" button that displays when there is a 400 or 500 API error.',
-    },
     dataTableContextProviderValue: {
       table: { disable: true }, // Don't show this in the Docs table
     },
@@ -244,13 +240,14 @@ export const Error500: Story = {
           message: 'Internal server error.',
           stack: ''
         }
-      }
+      },
+      relativeHomeUrlPrepend: '/provider-data',
     }
   },
   parameters: {
     docs: {
       description: {
-        story: 'Error message displayed for useDatastore API 500 error.',
+        story: 'Error message displayed for useDatastore API 500 error. This story also utilizes the `relativeHomeUrlPrepend` context property used to adjust the relative url of the "Back to home" button. This value is ultimately set via the `tabHrefPrepend` prop on the `Dataset` template.',
       },
     },
   },

--- a/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
+++ b/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
@@ -2,8 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import DatasetTable from './index';
 import DataTableContext from '../../templates/Dataset/DataTableContext';
 import { DataTableContextType } from '../../templates/Dataset/DataTableContext';
-import { DataTableActionsContext } from './DataTableActionsContext';
-import { DataTableActionsContextProps } from './DataTableActionsContext';
+import { DataTableActionsContext, DataTableActionsContextProps } from './DataTableActionsContext';
 import { MemoryRouter } from 'react-router-dom';
 import { mockResource } from '../../../__mocks__/mockResource';
 import { mockDistribution } from '../../../__mocks__/mockDistribution';
@@ -85,6 +84,7 @@ const meta: Meta<StoryArgs> = {
     showDisplaySettingsButton: true,
     showFullScreenButton: true,
     showInfoShareContainer: true,
+    errorHomeButtonHref: '/',
     dataTableContextProviderValue: defaultDataTableContextProviderValue,
     dataTableActionsContextProviderValue: defaultDataTableActionsContextProviderValue
   },
@@ -95,6 +95,25 @@ const meta: Meta<StoryArgs> = {
         component: `
 The DatasetTableTab component renders everything under the "Data Table" tab on a dataset detail page. The rendered
 content includes dataset download buttons, data table toolbar component, sharing options, and data table with pagination controls.
+        `,
+      },
+      source: {
+        code: `
+<DatasetTable
+  isModal={false}
+  showCopyLinkButton
+  showDataTableToolbar
+  showDisplaySettingsButton
+  showDownloadFilteredDataButton
+  showDownloadFullDataButton
+  showStoredQueryDownloadButton={false}
+  showFilterDatasetButton
+  showFullScreenButton
+  showInfoShareContainer
+  showManageColumnsButton
+  showTableResults
+  errorHomeButtonHref="/"
+/>
         `,
       },
     },
@@ -158,6 +177,10 @@ content includes dataset download buttons, data table toolbar component, sharing
     showInfoShareContainer: {
       control: 'boolean',
       description: 'Whether or not to show the text information and "Share" button below data table toolbar.',
+    },
+    errorHomeButtonHref: {
+      control: 'text',
+      description: 'Href value for the "Back to home" button that displays when there is a 400 or 500 API error.',
     },
     dataTableContextProviderValue: {
       table: { disable: true }, // Don't show this in the Docs table

--- a/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
+++ b/src/components/DatasetTableTab/DatasetTableTab.stories.tsx
@@ -1,0 +1,234 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import DatasetTable from './index';
+import DataTableContext from '../../templates/Dataset/DataTableContext';
+import { DataTableContextType } from '../../templates/Dataset/DataTableContext';
+import { DataTableActionsContext } from './DataTableActionsContext';
+import { DataTableActionsContextProps } from './DataTableActionsContext';
+import { MemoryRouter } from 'react-router-dom';
+import { mockResource } from '../../../__mocks__/mockResource';
+import { mockDistribution } from '../../../__mocks__/mockDistribution';
+import { ResourceType, DistributionType, ColumnType } from '../../types/dataset';
+
+// Created a "mocked" version of this type instead of importing it because most of the
+// properties are optional in the type defined in src/templates/Dataset/DataTableContext.tsx
+// and it causes a lot of TypeScript headaches when trying to manipulate the dataTableContextProviderValue
+// in the stories
+export type MockDataTableContextType = {
+  id: string | null,
+  resource: ResourceType,
+  distribution: DistributionType,
+  rootUrl: string,
+  customColumns: Array<ColumnType>,
+  dataDictionaryBanner: boolean,
+  datasetTableControls: boolean,
+  enableEmptyFilters: boolean
+}
+
+// Mock DataTableContext.Provider value
+const defaultDataTableContextProviderValue: MockDataTableContextType = {
+  id: 'wb6u-x2ny',
+  resource: mockResource,
+  distribution: mockDistribution,
+  rootUrl: '/api/1',
+  customColumns: [
+    { accessor: 'licensing_authority' },
+    { accessor: 'resident_state' },
+    { accessor: 'approved_license_level_loa' },
+    { accessor: 'appointment_level_loa' },
+    { accessor: 'approved_class_type' },
+  ],
+  dataDictionaryBanner: false,
+  datasetTableControls: true,
+  enableEmptyFilters: false,
+};
+
+// Mock DataTableActionsContext.Provider value
+const defaultDataTableActionsContextProviderValue: DataTableActionsContextProps = {
+  columnOrder: [
+    'npn',
+    'applicable_plan_year',
+    'individual_registration_completion_date',
+    'individual_marketplace_end_date',
+    'shop_registration_completion_date',
+    'shop_end_date',
+    'npn_valid_current_plan_year_only',
+  ],
+  columnVisibility: {},
+  page: 1,
+  setColumnOrder: () => {},
+  setColumnVisibility: () => {},
+  setPage: () => {},
+  setTableDensity: () => {},
+  tableDensity: 'normal',
+};
+
+// We are mixing actual component props with the context values so that we
+// can change said values for each story
+type StoryArgs = React.ComponentProps<typeof DatasetTable> & {
+  dataTableContextProviderValue: DataTableContextType;
+  dataTableActionsContextProviderValue: DataTableActionsContextProps;
+};
+
+const meta: Meta<StoryArgs> = {
+  title: 'Components/DatasetTableTab',
+  component: DatasetTable,
+  args: {
+    isModal: false,
+    showCopyLinkButton: true,
+    showDataTableToolbar: true,
+    showDownloadFilteredDataButton: true,
+    showDownloadFullDataButton: true,
+    showStoredQueryDownloadButton: false,
+    showTableResults: true,
+    showFilterDatasetButton: true,
+    showManageColumnsButton: true,
+    showDisplaySettingsButton: true,
+    showFullScreenButton: true,
+    showInfoShareContainer: true,
+    dataTableContextProviderValue: defaultDataTableContextProviderValue,
+    dataTableActionsContextProviderValue: defaultDataTableActionsContextProviderValue
+  },
+  parameters: {
+    layout: 'fullscreen',
+    docs: {
+      description: {
+        component: `
+The DatasetTableTab component renders everything under the "Data Table" tab on a dataset detail page. The rendered
+content includes dataset download buttons, data table toolbar component, sharing options, and data table with pagination controls.
+        `,
+      },
+    },
+  },
+  decorators: [
+    (Story, context) => (
+      <MemoryRouter>
+        <DataTableContext.Provider value={context.args.dataTableContextProviderValue}>
+          <DataTableActionsContext.Provider value={context.args.dataTableActionsContextProviderValue}>
+            <Story />
+          </DataTableActionsContext.Provider>
+        </DataTableContext.Provider>
+      </MemoryRouter>
+    ),
+  ],
+  argTypes: {
+    isModal: {
+      control: 'boolean',
+      description: 'Whether or not the dataset table is rendered within a modal.',
+    },
+    showCopyLinkButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Copy link to filtered data" button in the "Share" dropdown menu.',
+    },
+    showDataTableToolbar: {
+      control: 'boolean',
+      description: 'Whether or not to show the data table toolbar component, which includes everything above the data table.',
+    },
+    showDownloadFilteredDataButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Download filtered data (CSV)" button in the "Share" dropdown menu.',
+    },
+    showDownloadFullDataButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Download full dataset (CSV)" button.',
+    },
+    showStoredQueryDownloadButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Download stored query data (CSV)" button in the "Share" dropdown menu.',
+    },
+    showTableResults: {
+      control: 'boolean',
+      description: 'Whether or not to show the record display count in the data table toolbar component.',
+    },
+    showFilterDatasetButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Filter Dataset" button in the data table toolbar component.',
+    },
+    showManageColumnsButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Manage Columns" button in the data table toolbar component.',
+    },
+    showDisplaySettingsButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Display Settings" button in the data table toolbar component.',
+    },
+    showFullScreenButton: {
+      control: 'boolean',
+      description: 'Whether or not to show the "Full Screen" button in the data table toolbar component.',
+    },
+    showInfoShareContainer: {
+      control: 'boolean',
+      description: 'Whether or not to show the text information and "Share" button below data table toolbar.',
+    },
+    dataTableContextProviderValue: {
+      table: { disable: true }, // Don't show this in the Docs table
+    },
+    dataTableActionsContextProviderValue: {
+      table: { disable: true }, // Don't show this in the Docs table
+    },
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<StoryArgs>;
+
+export const Default: Story = {
+  args: {
+    ...meta.args
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Standard "Data Table" tab displayed on a dataset detail page.',
+      },
+    },
+  },
+};
+
+export const Error400: Story = {
+  args: {
+    ...meta.args,
+    dataTableContextProviderValue: {
+      ...defaultDataTableContextProviderValue,
+      resource: {
+        ...defaultDataTableContextProviderValue?.resource,
+        error: {
+          status: 400,
+          message: 'No datastore storage found for abc123',
+          stack: ''
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Error message displayed for useDatastore API 400 error.',
+      },
+    },
+  },
+}
+
+export const Error500: Story = {
+  args: {
+    ...meta.args,
+    dataTableContextProviderValue: {
+      ...defaultDataTableContextProviderValue,
+      resource: {
+        ...defaultDataTableContextProviderValue?.resource,
+        error: {
+          status: 500,
+          message: 'Internal server error.',
+          stack: ''
+        }
+      }
+    }
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: 'Error message displayed for useDatastore API 500 error.',
+      },
+    },
+  },
+}

--- a/src/components/DatasetTableTab/index.tsx
+++ b/src/components/DatasetTableTab/index.tsx
@@ -41,6 +41,7 @@ const DatasetTable = ({
   showDisplaySettingsButton = true,
   showFullScreenButton = true,
   showInfoShareContainer = true,
+  errorHomeButtonHref = '/',
 }: {
   isModal?: boolean;
   showCopyLinkButton?: boolean;
@@ -54,6 +55,7 @@ const DatasetTable = ({
   showDisplaySettingsButton?: boolean;
   showFullScreenButton?: boolean;
   showInfoShareContainer?: boolean;
+  errorHomeButtonHref?: string;
 }) => {
   const {
     id,
@@ -184,7 +186,7 @@ const DatasetTable = ({
         <p className="ds-u-padding-bottom--2 ds-u-margin-bottom--7">
           {useDatastoreErrorMessages[resourceErrorStatus].message}
         </p>
-        <Button href="/" variation="solid" className="">
+        <Button href={errorHomeButtonHref} variation="solid" className="">
           Go to home
         </Button>
       </div>

--- a/src/components/DatasetTableTab/index.tsx
+++ b/src/components/DatasetTableTab/index.tsx
@@ -26,6 +26,7 @@ export type DatasetTableTabProps = {
   dataDictionaryBanner: boolean;
   datasetTableControls: boolean;
   enableEmptyFilters?: boolean;
+  relativeHomeUrlPrepend?: string;
 };
 
 const DatasetTable = ({
@@ -41,7 +42,6 @@ const DatasetTable = ({
   showDisplaySettingsButton = true,
   showFullScreenButton = true,
   showInfoShareContainer = true,
-  errorHomeButtonHref = '/',
 }: {
   isModal?: boolean;
   showCopyLinkButton?: boolean;
@@ -55,7 +55,6 @@ const DatasetTable = ({
   showDisplaySettingsButton?: boolean;
   showFullScreenButton?: boolean;
   showInfoShareContainer?: boolean;
-  errorHomeButtonHref?: string;
 }) => {
   const {
     id,
@@ -64,6 +63,7 @@ const DatasetTable = ({
     rootUrl,
     customColumns = [],
     dataDictionaryBanner,
+    relativeHomeUrlPrepend,
   } = useContext(DataTableContext) as DatasetTableTabProps;
   const { page, setPage, tableDensity } = useContext(DataTableActionsContext);
 
@@ -186,7 +186,7 @@ const DatasetTable = ({
         <p className="ds-u-padding-bottom--2 ds-u-margin-bottom--7">
           {useDatastoreErrorMessages[resourceErrorStatus].message}
         </p>
-        <Button href={errorHomeButtonHref} variation="solid" className="">
+        <Button href={`${relativeHomeUrlPrepend}/`} variation="solid" className="">
           Go to home
         </Button>
       </div>

--- a/src/components/DatasetTableTab/index.tsx
+++ b/src/components/DatasetTableTab/index.tsx
@@ -3,7 +3,7 @@ import qs from 'qs';
 import DataTable from '../Datatable/Datatable';
 import { transformTableSortToQuerySort } from '../../services/useDatastore/transformSorts';
 import { buildCustomColHeaders } from '../../templates/FilteredResource/functions';
-import { Pagination, Spinner, Alert } from '@cmsgov/design-system';
+import { Pagination, Spinner, Button } from '@cmsgov/design-system';
 import QueryBuilder from '../QueryBuilder';
 import { DistributionType, ColumnType, ResourceType } from '../../types/dataset';
 import DataTableContext from '../../templates/Dataset/DataTableContext';
@@ -84,7 +84,25 @@ const DatasetTable = ({
     { encode: true }
   )}&format=csv`;
 
+  const useDatastoreErrorMessages: {
+    [key: number]: {
+      title: string,
+      message: string
+    }
+  } = {
+    400: {
+      title: 'Data unavailable',
+      message: 'This data is not available for preview at this time. Please try again later.',
+    },
+    500: {
+      title: 'Something went wrong',
+      message: 'Something went wrong on our end. Please try again later.',
+    },
+  };
+
+  // Data loaded successfully
   if (
+    !resource.error &&
     Object.keys(resource).length &&
     columns.length &&
     resource.schema &&
@@ -153,8 +171,29 @@ const DatasetTable = ({
         )}
       </>
     );
-  } else
+
+  // useDatastore error
+  } else if (resource.error && !resource.loading) {
+    const resourceErrorStatus = resource.error.status in useDatastoreErrorMessages ? resource.error.status : 500;
+
+    return (
+      <div>
+        <h2 className="ds-text-heading--lg ds-u-margin--0 ds-u-color--primary">
+          {useDatastoreErrorMessages[resourceErrorStatus].title}
+        </h2>
+        <p className="ds-u-padding-bottom--2 ds-u-margin-bottom--7">
+          {useDatastoreErrorMessages[resourceErrorStatus].message}
+        </p>
+        <Button href="/" variation="solid" className="">
+          Go to home
+        </Button>
+      </div>
+    );
+
+  // Data loading
+  } else {
     return <Spinner aria-valuetext="Dataset loading" role="status" className="ds-u-margin--3" />;
+  }
 };
 
 export default DatasetTable;

--- a/src/components/ManageColumns/ManageColumns.jsx
+++ b/src/components/ManageColumns/ManageColumns.jsx
@@ -68,10 +68,14 @@ const ManageColumns = ({
   // keep state in sync
   useEffect(() => {
     if (columnOrder?.length)
-      setCards(columnOrder.map(c => {
-        const column = columns.filter(col => col.id === c)[0];
-        return {id: column.id, visible: column.getIsVisible()}
-      }))
+      setCards(columnOrder
+        .map(id => columns.find(col => col.id === id)) // Get list of cards in order
+        .filter(Boolean) // Filter out an possible undefined/non-matches
+        .map(column => ({ // Normalize the data
+          id: column.id,
+          visible: column.getIsVisible(),
+        }))
+      )
   }, [columnOrder])
 
   // Update cards state when columnVisibility changes
@@ -202,10 +206,14 @@ const ManageColumns = ({
                   onClick={() => {
                     // reset to default column order and set all cards to visible
                     // do not save this to the table state until the "Save" button is clicked
-                    setCards(defaultColumnOrder.map(column => {
-                      const card = cards.filter(c => c.id === column)[0]
-                      return {...card, visible: true }
-                    }));
+                    setCards(defaultColumnOrder
+                      .map(id => cards.find(c => c.id === id)) // Get list of cards in order
+                      .filter(Boolean) // Filter out an possible undefined/non-matches
+                      .map(card => ({ // Normalize the data
+                        ...card,
+                        visible: true,
+                      }))
+                    );
                   }}
                 >
                   Reset Columns

--- a/src/components/ManageColumns/ManageColumns.jsx
+++ b/src/components/ManageColumns/ManageColumns.jsx
@@ -70,7 +70,7 @@ const ManageColumns = ({
     if (columnOrder?.length)
       setCards(columnOrder
         .map(id => columns.find(col => col.id === id)) // Get list of cards in order
-        .filter(Boolean) // Filter out an possible undefined/non-matches
+        .filter(Boolean) // Filter out any possible undefined/non-matches
         .map(column => ({ // Normalize the data
           id: column.id,
           visible: column.getIsVisible(),
@@ -208,7 +208,7 @@ const ManageColumns = ({
                     // do not save this to the table state until the "Save" button is clicked
                     setCards(defaultColumnOrder
                       .map(id => cards.find(c => c.id === id)) // Get list of cards in order
-                      .filter(Boolean) // Filter out an possible undefined/non-matches
+                      .filter(Boolean) // Filter out any possible undefined/non-matches
                       .map(card => ({ // Normalize the data
                         ...card,
                         visible: true,

--- a/src/services/useDatastore/useDatastore.jsx
+++ b/src/services/useDatastore/useDatastore.jsx
@@ -75,12 +75,26 @@ const useDatastore = (
   // Change whether distribution API or dataset API is used based on option
   const queryID = useDatasetAPI && datasetID ? `${datasetID}/0` : id;
 
+  async function fetchJson(url) {
+    const res = await fetch(url);
+    const body = await res.json().catch(() => ({}));
+
+    if (!res.ok) {
+      const err = new Error(body.message || body.error || res.statusText);
+      err.status = res.status;
+
+      throw err;
+    }
+
+    return body;
+  }
+
   const {data, isPending, error} = useQuery({
     queryKey: ["datastore" + id + paramsString],
     queryFn: () => {
-      setCount(null)
-      return fetch(`${rootUrl}/datastore/query/${queryID}?${paramsString}`)
-        .then(res => res.json())
+      setCount(null);
+
+      return fetchJson(`${rootUrl}/datastore/query/${queryID}?${paramsString}`);
     },
     enabled: enabled
   })
@@ -92,12 +106,11 @@ const useDatastore = (
         results: false,
         count: true,
         schema: true
-      }
-      return fetch(`${rootUrl}/datastore/query/${queryID}?${qs.stringify(acaToParams(unfilteredParams, ACA))}`)
-        .then(res => res.json())
+      };
+
+      return fetchJson(`${rootUrl}/datastore/query/${queryID}?${qs.stringify(acaToParams(unfilteredParams, ACA))}`);
     },
   })
-  
 
   useEffect(() => {
     if(data) {
@@ -123,6 +136,7 @@ const useDatastore = (
 
   return {
     loading: enabled ? isPending : false,
+    error,
     values,
     count,
     columns,

--- a/src/templates/Dataset/DataTableContext.tsx
+++ b/src/templates/Dataset/DataTableContext.tsx
@@ -3,14 +3,15 @@ import { DistributionType, ResourceType, ColumnType } from '../../types/dataset'
 
 // create context
 export type DataTableContextType = {
-  id: string | null,
-  resource?: ResourceType,
-  distribution?: DistributionType,
-  rootUrl?: string,
-  customColumns?: Array<ColumnType>,
-  dataDictionaryBanner?: boolean,
-  datasetTableControls?: boolean,
-  enableEmptyFilters?: boolean
+  id: string | null;
+  resource?: ResourceType;
+  distribution?: DistributionType;
+  rootUrl?: string;
+  customColumns?: Array<ColumnType>;
+  dataDictionaryBanner?: boolean;
+  datasetTableControls?: boolean;
+  enableEmptyFilters?: boolean;
+  relativeHomeUrlPrepend?: string;
 }
 const DataTableContext = createContext<DataTableContextType>({ id: null})
 

--- a/src/templates/Dataset/Dataset.stories.tsx
+++ b/src/templates/Dataset/Dataset.stories.tsx
@@ -93,6 +93,10 @@ The default tab is Data Table when the distribution is CSV, otherwise Overview.
     showRowLimitNotice: {
       control: 'boolean',
       description: 'When true, shows a notice when row count is limited. Defaults to false.',
+    },
+    tabHrefPrepend: {
+      control: 'text',
+      description: 'Prepends the provided string to the relative url value of the tab href\'s on the dataset detail page.',
     }
   },
   tags: ['autodocs'],
@@ -121,7 +125,8 @@ const defaultArgs = {
   disableTableControls: false,
   hideDataDictionary: false,
   showRowLimitNotice: false,
-  dataDictionaryUrl: ''
+  dataDictionaryUrl: '',
+  tabHrefPrepend: '',
 };
 
 export const Default: Story = {

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -88,7 +88,6 @@ const Dataset = ({
     distribution = distributions[0];
   }
 
-
   const resource = useDatastore(
     '',
     rootUrl,

--- a/src/templates/Dataset/index.tsx
+++ b/src/templates/Dataset/index.tsx
@@ -230,7 +230,8 @@ const Dataset = ({
                           customColumns: customColumns,
                           dataDictionaryBanner: (dataDictionaryBanner && displayDataDictionaryTab),
                           datasetTableControls: !disableTableControls,
-                          enableEmptyFilters: enableEmptyFilters
+                          enableEmptyFilters: enableEmptyFilters,
+                          relativeHomeUrlPrepend: tabHrefPrepend,
                         }}>
                           <DataTableStateWrapper />
                         </DataTableContext.Provider>

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -8,8 +8,20 @@ export type DistributionDataType = {
   describedBy: string,
   describedByType: string,
   mediaType: string,
+  "%Ref:downloadURL": {
+    identifier: string,
+    data: DistributionSubDataType,
+  }[],
+  "@type": string,
+}
+
+export type DistributionSubDataType = {
+  filePath: string,
+  identifier: string,
+  perspective: string,
+  version: string,
+  checksum: string | null,
   mimeType: string,
-  "%Ref:downloadURL": DistributionType[],
 }
 
 export type DistributionType = {
@@ -56,7 +68,7 @@ export type PropertyType = {
 }
 
 export type ColumnType = {
-  header: string,
+  header?: string,
   accessor: string
 }
 

--- a/src/types/dataset.ts
+++ b/src/types/dataset.ts
@@ -101,6 +101,7 @@ export type DatasetPageType = {
 
 
 export type ResourceType = {
+  error: { status: number, message: string, stack: string } | null,
   columns: Array<string>,
   count: number | null,
   totalRows: number,


### PR DESCRIPTION
## JIRA Ticket(s)
- WCMS-28443: Replace the spinner with a message that the data is not available: Part 2

## What
- Added error messaging to Data table tab.
- Created Storybook stories for DatasetTableTab component.

## How to Test:
1. In a local OD repo like data.healthcare, install `@civicactions/cmsds-open-data-components@4.1.7-alpha.4`.
2. Run `npm run storybook`.
3. Under "Components", view the "DatasetTableTab" item.
4. Verify the component loads correctly.
5. Verify the "Error400" item loads correctly with "Data unavailable" and "This data is not available for preview at this time. Please try again later." along with a "Go to home" button. 
6. Verify the "Error500" item loads correctly with "Something went wrong" and "Something went wrong on our end. Please try again later." along with a "Go to home" button. 
7. Done.