### PR TITLE
WCMS-28207: Align Tealium search submission with new search

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 6, 2026*  
+*Last updated: May 19, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/src/templates/DatasetSearch/DatasetSearch.stories.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.stories.tsx
@@ -126,7 +126,7 @@ Key features:
     },
     analytics: {
       control: 'boolean',
-      description: 'Fire the onAnalyticsEvent callback when a search term is submitted and/or a topic or tag is selected and/or search results are sorted.',
+      description: 'Fire the onAnalyticsEvent callback when a search term is submitted and/or a topic or tag is selected and/or search results are sorted. False by default.',
     },
     onAnalyticsEvent: {
       action: 'onAnalyticsEvent fired', // Won't actually fire because it's dependent on url querystring changes

--- a/src/templates/DatasetSearch/DatasetSearch.stories.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.stories.tsx
@@ -27,6 +27,8 @@ const meta: Meta<typeof DatasetSearch> = {
     dataDictionaryLinks: false,
     showDateDetails: false,
     showTopics: false,
+    analytics: true,
+    onAnalyticsEvent: () => {},
   },
   parameters: {
     layout: 'fullscreen',
@@ -122,6 +124,14 @@ Key features:
       control: 'boolean',
       description: 'Show topic pills on dataset items.',
     },
+    analytics: {
+      control: 'boolean',
+      description: 'Fire the onAnalyticsEvent callback when a search term is submitted and/or a topic or tag is selected and/or search results are sorted.',
+    },
+    onAnalyticsEvent: {
+      action: 'onAnalyticsEvent fired', // Won't actually fire because it's dependent on url querystring changes
+      description: 'Function that is fired when a search term is submitted and/or a topic or tag is selected and/or search results are sorted. A react-router-dom location object is passed as an argument.'
+    }
   },
   tags: ['autodocs'],
 };

--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -1,5 +1,5 @@
 import React, { useContext, useEffect, useMemo, useState } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams, useNavigate, useLocation } from 'react-router-dom';
 import qs from 'qs';
 import axios from 'axios';
 import withQueryProvider from '../../utilities/QueryProvider/QueryProvider';
@@ -48,12 +48,15 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
     updateDateMonthYearOnly = false,
     showTopics = false,
     topicSlugFunction = undefined,
+    analytics = false,
+    onAnalyticsEvent = () => {},
     children
   } = props;
   const { ACA } = useContext(ACAContext);
 
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const location = useLocation();
 
   // Derive all search state from URL params
   const selectedFacets: SelectedFacetsType = useMemo(() => {
@@ -170,6 +173,12 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
     if (!isPending && (!data || !data.data.results)) return 'Could not connect to the API.';
     return `Showing ${currentResultNumbers.startingNumber} to ${currentResultNumbers.endingNumber} of ${currentResultNumbers.total} datasets`;
   }, [data, isPending, noResults, currentResultNumbers]);
+
+  useEffect(() => {
+    if (analytics && location.search) {
+      onAnalyticsEvent(location);
+    }
+  }, [analytics, location.search])
 
   return (
     <>

--- a/src/templates/DatasetSearch/datasetsearch.test.jsx
+++ b/src/templates/DatasetSearch/datasetsearch.test.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import axios from 'axios';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DatasetSearch from './index';
 import { MemoryRouter } from 'react-router-dom';

--- a/src/templates/DatasetSearch/datasetsearch.test.jsx
+++ b/src/templates/DatasetSearch/datasetsearch.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import axios from 'axios';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import DatasetSearch from './index';
 import { MemoryRouter } from 'react-router-dom';
@@ -106,6 +107,67 @@ describe('<DatasetSearch />', () => {
       jest.useFakeTimers();
     });
     expect(screen.getByTestId('child-element')).toBeInTheDocument();
+  });
+
+  test('Calls onAnalyticsEvent when analytics enabled', async () => {
+    const onAnalyticsEvent = jest.fn();
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/datasets?fulltext=test']}>
+          <DatasetSearch
+            rootUrl={rootUrl}
+            analytics
+            onAnalyticsEvent={onAnalyticsEvent}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    await waitFor(() => {
+      expect(onAnalyticsEvent).toHaveBeenCalledTimes(1);
+    });
+
+    const arg = onAnalyticsEvent.mock.calls[0][0];
+
+    expect(arg.pathname).toBe('/datasets');
+    expect(arg.search).toBe('?fulltext=test');
+  });
+
+  test('Does not call onAnalyticsEvent when analytics is disabled', async () => {
+    const onAnalyticsEvent = jest.fn();
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/datasets?fulltext=test']}>
+          <DatasetSearch
+            rootUrl={rootUrl}
+            analytics={false}
+            onAnalyticsEvent={onAnalyticsEvent}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    expect(onAnalyticsEvent).not.toHaveBeenCalled();
+  });
+
+  test('Does not call onAnalyticsEvent when no search params exist', async () => {
+    const onAnalyticsEvent = jest.fn();
+
+    await act(async () => {
+      render(
+        <MemoryRouter initialEntries={['/datasets']}>
+          <DatasetSearch
+            rootUrl={rootUrl}
+            analytics
+            onAnalyticsEvent={onAnalyticsEvent}
+          />
+        </MemoryRouter>
+      );
+    });
+
+    expect(onAnalyticsEvent).not.toHaveBeenCalled();
   });
 });
 

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -1,3 +1,5 @@
+import { Location } from "react-router-dom";
+
 export type SearchDistributionType = {
   identifier: string;
   downloadURL: string;
@@ -43,6 +45,8 @@ export type DatasetSearchPageProps = {
   updateDateMonthYearOnly?: boolean;
   showTopics?: boolean;
   topicSlugFunction?: (topic: string) => string | undefined;
+  analytics?: boolean;
+  onAnalyticsEvent?: (url: Location) => void;
   children?: React.ReactNode;
 };
 


### PR DESCRIPTION
## JIRA Ticket(s)
- WCMS-28207: Align Tealium search submission with new search

## What
- Added `analytics` and `onAnalyticsEvent` props to DatasetSearch template.
- Updated DatasetSearch Storybook stories.
- Updated DatasetSearch unit tests.

## How to Test:
You can use [this PDC PR](https://github.cms.gov/PQDC/pqdc-dkan/pull/2043) to test with to save yourself manual setup if you'd like. Otherwise, continue on below.

I highly recommend installing the [Tealium Tools Browser extension](https://docs.tealium.com/iq-tag-management/tealium-tools/browser-extension/) for debugging Tealium UTag calls.
1. In a local OD repo like PDC, install `@civicactions/cmsds-open-data-components@4.1.7-alpha.3`.
2. You will have to manually set up a scenario to test with in the DatasetSearch component. See the attached screenshot at https://jira.cms.gov/browse/WCMS-28207 to see how this is done for PDC using the new `analytics` and `onAnalyticsEvent` props.
3. In the React root, run 'npm i && npm run start'.
4. Visit <LOCALHOST_DOMAIN>/datasets.
5. Open Tealium Tools > UTag Debugger.
6. You should see no events for the initial <LOCALHOST_DOMAIN>/datasets page load.
7. Enter and submit a search term.
8. Note: I like to uncheck everything under "Show Data" in the UTag Debugger to un-clutter the UI.
9. Verify a utag.view is sent containing the "fulltext" query string parameter with your submitted search term as the value. It should look something like the attached screenshot at https://jira.cms.gov/browse/WCMS-28207.
10. Now check a topic in the sidebar.
11. Verify another utag.view is sent containing a "theme[0]" query string parameter with your checked topic as the value.
12. Now check a tag in the sidebar.
13. Verify another utag.view is sent containing a "keyword[0]" query string parameter with your checked tag as the value.
14. Now sort the search results via "Sort" dropdown.
15. Verify another utag.view is sent containing a "sortOrder" query string parameter with your selected sort option as the value (asc, desc, ect.).
16. Done.