### PR TITLE
Resolve issue Where Menu and Search Modal did not close after navigate

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -62,7 +62,7 @@ This document provides a comprehensive inventory of all components, services, te
 | Component | [ResourcePreview](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/ResourcePreview) | ✅ Public | ❌ No Story | ❌ No Tests |
 | Component | [SearchButton](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SearchButton) | ❌ Internal | ✅ Has Story | ❌ No Tests |
 | Component | [SearchInput](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SearchInput) | ✅ Public | ✅ Has Story | ❌ No Tests |
-| Component | [SearchModal](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SearchModal) | ❌ Internal | ✅ Has Story | ❌ No Tests |
+| Component | [SearchModal](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SearchModal) | ❌ Internal | ✅ Has Story | ✅ Has Tests |
 | Component | [SidebarNavigation](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SidebarNavigation) | ✅ Public | ✅ Has Story | ❌ No Tests |
 | Component | [SitewideDataDictionaryTable](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SitewideDataDictionaryTable) | ❌ Internal | ✅ Has Story | ❌ No Tests |
 | Component | [SubMenu](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/SubMenu) | ✅ Public | ✅ Has Story | ✅ Has Tests |
@@ -123,11 +123,11 @@ This document provides a comprehensive inventory of all components, services, te
 
 | Category | Total | With Stories | With Tests | With Both | With Neither |
 |----------|-------|--------------|------------|-----------|--------------|
-| Components | 64 | 41 (64%) | 27 (42%) | 16 (25%) | 12 (19%) |
+| Components | 64 | 41 (64%) | 28 (44%) | 17 (27%) | 12 (19%) |
 | Templates | 11 | 10 (91%) | 3 (27%) | 3 (27%) | 1 (9%) |
 | Services/Hooks/Contexts | 9 | 0 (0%) | 0 (0%) | 0 (0%) | 9 (100%) |
 | Utilities/Types/Assets | 12 | 0 (0%) | 0 (0%) | 0 (0%) | 12 (100%) |
-| **Project Total** | **96** | **51 (53%)** | **30 (31%)** | **19 (20%)** | **34 (35%)** |
+| **Project Total** | **96** | **51 (53%)** | **31 (32%)** | **20 (21%)** | **34 (35%)** |
 
 ---
 
@@ -137,5 +137,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: May 20, 2026*  
+*Last updated: May 27, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -41,7 +41,7 @@ This document provides a comprehensive inventory of all components, services, te
 | Component | [FullScreenDataTable](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/FullScreenDataTable) | ❌ Internal | ❌ No Story | ❌ No Tests |
 | Component | [HeaderNav](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderNav) | ✅ Public | ❌ No Story | ❌ No Tests |
 | Component | [HeaderNavIconLink](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderNavIconLink) | ✅ Public | ✅ Has Story | ❌ No Tests |
-| Component | [HeaderSearch](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderSearch) | ✅ Public | ✅ Has Story | ❌ No Tests |
+| Component | [HeaderSearch](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderSearch) | ✅ Public | ✅ Has Story | ✅ Has Tests |
 | Component | [HeaderSiteTitle](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderSiteTitle) | ✅ Public | ✅ Has Story | ❌ No Tests |
 | Component | [HeaderTagline](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/HeaderTagline) | ✅ Public | ✅ Has Story | ❌ No Tests |
 | Component | [Hero](https://github.com/GetDKAN/cmsds-open-data-components/tree/main/src/components/Hero) | ✅ Public | ✅ Has Story | ❌ No Tests |
@@ -123,11 +123,11 @@ This document provides a comprehensive inventory of all components, services, te
 
 | Category | Total | With Stories | With Tests | With Both | With Neither |
 |----------|-------|--------------|------------|-----------|--------------|
-| Components | 64 | 41 (64%) | 28 (44%) | 17 (27%) | 12 (19%) |
+| Components | 64 | 41 (64%) | 29 (45%) | 18 (28%) | 12 (19%) |
 | Templates | 11 | 10 (91%) | 3 (27%) | 3 (27%) | 1 (9%) |
 | Services/Hooks/Contexts | 9 | 0 (0%) | 0 (0%) | 0 (0%) | 9 (100%) |
 | Utilities/Types/Assets | 12 | 0 (0%) | 0 (0%) | 0 (0%) | 12 (100%) |
-| **Project Total** | **96** | **51 (53%)** | **31 (32%)** | **20 (21%)** | **34 (35%)** |
+| **Project Total** | **96** | **51 (53%)** | **32 (33%)** | **21 (22%)** | **34 (35%)** |
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.1.7",
+      "version": "4.1.8",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.1.7",
+  "version": "4.1.8",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/HeaderSearch/HeaderSearch.test.tsx
+++ b/src/components/HeaderSearch/HeaderSearch.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import HeaderSearch from './index';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('@cmsgov/design-system', () => ({
+  Button: ({ children, onClick, className, type, onDark, variation }) => (
+    <button onClick={onClick} className={className} type={type}>
+      {children}
+    </button>
+  ),
+  Dialog: ({ heading, actions, onExit, isOpen }) => (
+    <div data-testid="search-dialog">
+      <h2>{heading}</h2>
+      <button onClick={onExit} aria-label="Close dialog">
+        Close
+      </button>
+      <div>{actions}</div>
+    </div>
+  ),
+  TextField: ({ label, onChange, value, name, labelClassName, errorMessage }) => (
+    <div>
+      <label className={labelClassName} htmlFor={name}>
+        {label}
+      </label>
+      <input id={name} name={name} value={value} onChange={onChange} aria-label={label} />
+      {errorMessage && <span role="alert">{errorMessage}</span>}
+    </div>
+  ),
+}));
+
+const renderHeaderSearch = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <HeaderSearch {...props} />
+    </MemoryRouter>
+  );
+
+describe('<HeaderSearch />', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders the Search button', () => {
+    renderHeaderSearch();
+    expect(screen.getByRole('button', { name: /Search/i })).toBeInTheDocument();
+  });
+
+  it('modal is not visible on initial render', () => {
+    renderHeaderSearch();
+    expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when the Search button is clicked', async () => {
+    renderHeaderSearch();
+    await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+    expect(screen.getByTestId('search-dialog')).toBeInTheDocument();
+  });
+
+  it('closes the modal via the onExit callback', async () => {
+    renderHeaderSearch();
+    await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+    expect(screen.getByTestId('search-dialog')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Close dialog/i }));
+    expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+  });
+
+  describe('search form submission', () => {
+    it('navigates to /datasets with the search term when not on /datasets', async () => {
+      renderHeaderSearch();
+      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), 'cancer');
+      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/datasets?fulltext=cancer');
+    });
+
+    it('closes the modal after navigating to /datasets', async () => {
+      renderHeaderSearch();
+      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), 'cancer');
+      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
+
+      expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+    });
+
+    it('shows a validation error for an invalid search term', async () => {
+      renderHeaderSearch();
+      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), '!!!');
+      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
+
+      expect(mockNavigate).not.toHaveBeenCalled();
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -25,6 +25,7 @@ const HeaderSearch = (props: HeaderSearchProps) => {
 
         if (window.location.pathname !== '/datasets') {
           navigate(`/datasets?fulltext=${modalSearchTerm}`);
+          setModalSearch(false);
         } else {
           window.location.search = `fulltext=${modalSearchTerm}`;
           setModalSearch(false);

--- a/src/components/SearchModal/SearchModal.test.jsx
+++ b/src/components/SearchModal/SearchModal.test.jsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import SearchModal from './index';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('react-responsive', () => ({
+  useMediaQuery: jest.fn(() => false),
+}));
+
+jest.mock('@cmsgov/design-system', () => ({
+  Button: ({ children, onClick, className, type, onDark, variation, size }) => (
+    <button onClick={onClick} className={className} type={type}>
+      {children}
+    </button>
+  ),
+  Dialog: ({ heading, actions, onExit }) => (
+    <div data-testid="search-dialog">
+      <h2>{heading}</h2>
+      <button onClick={onExit} aria-label="Close dialog">
+        Close
+      </button>
+      <div>{actions}</div>
+    </div>
+  ),
+  TextField: ({ label, onChange, value, name, labelClassName }) => (
+    <div>
+      <label className={labelClassName} htmlFor={name}>
+        {label}
+      </label>
+      <input id={name} name={name} value={value} onChange={onChange} aria-label={label} />
+    </div>
+  ),
+}));
+
+const renderSearchModal = (props = {}) =>
+  render(
+    <MemoryRouter>
+      <SearchModal {...props} />
+    </MemoryRouter>
+  );
+
+describe('<SearchModal />', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it('renders the Search button', () => {
+    renderSearchModal();
+    expect(screen.getByRole('button', { name: /Search/i })).toBeInTheDocument();
+  });
+
+  it('modal is not visible on initial render', () => {
+    renderSearchModal();
+    expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the modal when the Search button is clicked', async () => {
+    renderSearchModal();
+    await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+    expect(screen.getByTestId('search-dialog')).toBeInTheDocument();
+  });
+
+  it('renders the heading inside the modal', async () => {
+    renderSearchModal({ headingText: 'Find Datasets' });
+    await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+    expect(screen.getByRole('heading', { name: 'Find Datasets' })).toBeInTheDocument();
+  });
+
+  it('closes the modal via the onExit callback', async () => {
+    renderSearchModal();
+    await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+    expect(screen.getByTestId('search-dialog')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: /Close dialog/i }));
+    expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+  });
+
+  describe('search form submission', () => {
+    it('navigates to /datasets with the search term when not on /datasets', async () => {
+      renderSearchModal();
+      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), 'cancer');
+      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
+
+      expect(mockNavigate).toHaveBeenCalledWith('/datasets?fulltext=cancer');
+    });
+
+    it('closes the modal after navigating to /datasets', async () => {
+      renderSearchModal();
+      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
+
+      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), 'cancer');
+      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
+
+      expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/SearchModal/index.jsx
+++ b/src/components/SearchModal/index.jsx
@@ -18,6 +18,7 @@ const SearchModal = ({
     if (window) {
       if (window.location.pathname !== '/datasets') {
         navigate(`/datasets?fulltext=${modalSearchTerm}`);
+        setModalSearch(false);
       } else {
         window.location.search = `fulltext=${modalSearchTerm}`;
         setModalSearch(false);

--- a/src/components/SubMenu/index.tsx
+++ b/src/components/SubMenu/index.tsx
@@ -1,4 +1,5 @@
 import React, { ReactElement, ReactNode, useEffect, useState, useRef } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Button, ArrowIcon } from '@cmsgov/design-system';
 import HeaderContext from '../../templates/Header/HeaderContext';
 import { NavLinkArray, SubmenuElementProps } from '../../types/misc';
@@ -16,6 +17,11 @@ export type SubMenuProps = {
 const SubMenu = ({ link, linkClasses, subLinkClasses, wrapLabel = true }: SubMenuProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const headerContext = React.useContext(HeaderContext);
+  const location = useLocation();
+
+  useEffect(() => {
+    setIsExpanded(false);
+  }, [location]);
   const innerHtml: ReactNode = wrapLabel ? <span>{link.label}</span> : link.label;
   const menu = useRef<HTMLLIElement>(null);
   useEffect(() => {

--- a/src/components/SubMenu/submenu.test.tsx
+++ b/src/components/SubMenu/submenu.test.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
-import { MemoryRouter } from 'react-router-dom';
+import { MemoryRouter, useNavigate } from 'react-router-dom';
 import HeaderContext from '../../templates/Header/HeaderContext';
 import SubMenu from './index';
 import { NavLinkArray, SubmenuElementProps } from '../../types/misc';
@@ -146,6 +146,33 @@ describe('<SubMenu />', () => {
     expect(button).toHaveAttribute('aria-expanded', 'true');
 
     fireEvent.mouseDown(document.body);
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('closes the submenu when the route changes', async () => {
+    const NavigationTrigger = () => {
+      const navigate = useNavigate();
+      return <button onClick={() => navigate('/new-page')}>Navigate away</button>;
+    };
+
+    render(
+      <MemoryRouter>
+        <HeaderContext.Provider value={mockHeaderContext}>
+          <nav>
+            <ul>
+              <SubMenu link={staticSubmenuLink} linkClasses="" subLinkClasses="" wrapLabel={true} />
+            </ul>
+          </nav>
+          <NavigationTrigger />
+        </HeaderContext.Provider>
+      </MemoryRouter>
+    );
+
+    const button = screen.getByRole('button', { name: /Resources/i });
+    await userEvent.click(button);
+    expect(button).toHaveAttribute('aria-expanded', 'true');
+
+    await userEvent.click(screen.getByRole('button', { name: /Navigate away/i }));
     expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 

--- a/src/components/SubMenuStaticList/index.jsx
+++ b/src/components/SubMenuStaticList/index.jsx
@@ -15,7 +15,7 @@ const SubMenuStaticList = ({submenuArray, subLinkClasses, setIsExpanded}) =>  {
           <NavLink
             to={s.url}
             className={`ds-u-display-flex ds-u-align-items--center ${subLinkClasses}`}
-            onClick={() => setIsExpanded(prev => !prev)}
+            onClick={() => setIsExpanded(false)}
           >
             {s.icon ?? null}
             <span>


### PR DESCRIPTION
Resolves an issues specific to PDC. Other sites should be unaffected by this update. Submenu drop-downs and search modal were not closing after navigate events.  PDC has already been tested with the alpha, so we just need to confirm the other sties still work as expected. 

**Testing Steps:**
- On one of the data sites other than PDC - install the `4.1.8-alpha.1` alpha release
- test a few links in the header dropdown to confirm the submenu collapses when navigating to a new page
- click on the search modal in the header and perform a search
- confirm the modal closes after navigating to the search page.
- run all tests and confirm no errors. `npm run test`

