### PR TITLE
WCMS-28500: Ignore Special Characters in Search

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -134,5 +134,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: July 9, 2026*  
+*Last updated: July 15, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -134,5 +134,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: July 16, 2026*  
+*Last updated: July 17, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -134,5 +134,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: June 15, 2026*  
+*Last updated: July 8, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -134,5 +134,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: July 8, 2026*  
+*Last updated: July 9, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.2.0",
+      "version": "4.2.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0-alpha.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/DatasetListSubmenu/DatasetListSubmenu.tsx
+++ b/src/components/DatasetListSubmenu/DatasetListSubmenu.tsx
@@ -44,7 +44,7 @@ const DatasetListSubmenu = ({
   const { data, isPending, error } = useQuery({
     queryKey: ["datasets", params],
     queryFn: () => {
-      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: false })}`)
+      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: true })}`)
     }
   });
 

--- a/src/components/HeaderSearch/HeaderSearch.test.tsx
+++ b/src/components/HeaderSearch/HeaderSearch.test.tsx
@@ -94,16 +94,5 @@ describe('<HeaderSearch />', () => {
 
       expect(screen.queryByTestId('search-dialog')).not.toBeInTheDocument();
     });
-
-    it('shows a validation error for an invalid search term', async () => {
-      renderHeaderSearch();
-      await userEvent.click(screen.getByRole('button', { name: /^Search$/i }));
-
-      await userEvent.type(screen.getByRole('textbox', { name: /Search Term/i }), '!!!');
-      fireEvent.submit(screen.getByRole('textbox', { name: /Search Term/i }).closest('form'));
-
-      expect(mockNavigate).not.toHaveBeenCalled();
-      expect(screen.getByRole('alert')).toBeInTheDocument();
-    });
   });
 });

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -20,13 +20,8 @@ const HeaderSearch = (props: HeaderSearchProps) => {
     e.preventDefault();
 
     if (window) {
-      if (window.location.pathname !== '/datasets') {
-        navigate(`/datasets?fulltext=${modalSearchTerm}`);
-        setModalSearch(false);
-      } else {
-        window.location.search = `fulltext=${modalSearchTerm}`;
-        setModalSearch(false);
-      }
+      navigate(`/datasets?fulltext=${modalSearchTerm}`);
+      setModalSearch(false);
     }
   }
 

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -20,7 +20,11 @@ const HeaderSearch = (props: HeaderSearchProps) => {
     e.preventDefault();
 
     if (window) {
-      navigate(`/datasets?fulltext=${modalSearchTerm}`);
+      const params = new URLSearchParams({
+        fulltext: modalSearchTerm,
+      });
+
+      navigate(`/datasets?${params.toString()}`);
       setModalSearch(false);
     }
   }

--- a/src/components/HeaderSearch/index.tsx
+++ b/src/components/HeaderSearch/index.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { Button, Dialog, TextField } from "@cmsgov/design-system";
-import { isValidSearch } from "../../templates/DatasetSearch/DatasetSearch";
 import HeaderContext from "../../templates/Header/HeaderContext";
 
 import "./header-search.scss";
@@ -16,24 +15,17 @@ const HeaderSearch = (props: HeaderSearchProps) => {
   const { isMobile } = useContext(HeaderContext);
   const [modalSearchTerm, setModalSearchTerm] = useState('');
   const [modalSearch, setModalSearch] = useState(false);
-  const [invalidSearch, setInvalidSearch] = useState<boolean>(false);
 
   function searchForDataset(e: React.SyntheticEvent) {
     e.preventDefault();
 
     if (window) {
-      if (isValidSearch(modalSearchTerm)) {
-        setInvalidSearch(false);
-
-        if (window.location.pathname !== '/datasets') {
-          navigate(`/datasets?fulltext=${modalSearchTerm}`);
-          setModalSearch(false);
-        } else {
-          window.location.search = `fulltext=${modalSearchTerm}`;
-          setModalSearch(false);
-        }
+      if (window.location.pathname !== '/datasets') {
+        navigate(`/datasets?fulltext=${modalSearchTerm}`);
+        setModalSearch(false);
       } else {
-        setInvalidSearch(true);
+        window.location.search = `fulltext=${modalSearchTerm}`;
+        setModalSearch(false);
       }
     }
   }
@@ -61,8 +53,6 @@ const HeaderSearch = (props: HeaderSearchProps) => {
               }}
             >
               <TextField
-                errorMessage={invalidSearch ? 'No special characters allowed. Please enter a valid search term.' : undefined}
-                errorPlacement='bottom'
                 value={modalSearchTerm}
                 fieldClassName="ds-u-display--inline-block ds-u-margin--0"
                 className="ds-l-col--9"
@@ -70,7 +60,6 @@ const HeaderSearch = (props: HeaderSearchProps) => {
                 name="search-modal"
                 labelClassName="ds-u-visibility--screen-reader"
                 onChange={(e) => {
-                  setInvalidSearch(false);
                   setModalSearchTerm(e.target.value)
                 }}
               />

--- a/src/components/Hero/Hero.scss
+++ b/src/components/Hero/Hero.scss
@@ -1,3 +1,0 @@
-.dc-c-hero .ds-c-inline-error {
-  max-width: none;
-}

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -29,17 +29,6 @@ describe('Hero', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/datasets?fulltext=widgets');
   });
 
-  it('shows an error and does not navigate when the query has special characters', async () => {
-    const user = userEvent.setup();
-    renderHero();
-    await user.type(screen.getByLabelText('Search for a dataset'), 'bad$query');
-    await user.click(screen.getByRole('button', { name: /search/i }));
-    expect(mockNavigate).not.toHaveBeenCalled();
-    expect(
-      screen.getByText('No special characters allowed. Please enter a valid search term.'),
-    ).toBeInTheDocument();
-  });
-
   it('uses custom searchUrl and searchKey props', async () => {
     const user = userEvent.setup();
     renderHero({ searchUrl: 'catalog', searchKey: 'q', searchButtonText: 'Go' });

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -16,7 +16,11 @@ const Hero = ({
   function submitHero(e) {
     e.preventDefault();
 
-    navigate(`/${searchUrl}?${searchKey}=${searchValue}`);
+    const params = new URLSearchParams({
+      [searchKey]: searchValue
+    });
+
+    navigate(`/${searchUrl}?${params.toString()}`);
   }
 
   return (

--- a/src/components/Hero/index.jsx
+++ b/src/components/Hero/index.jsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button, TextField } from '@cmsgov/design-system';
-import { isValidSearch } from '../../templates/DatasetSearch/DatasetSearch';
-import './Hero.scss';
 
 const Hero = ({
   title,
@@ -13,19 +11,12 @@ const Hero = ({
   searchButtonText = 'Search'
 }) => {
   const navigate = useNavigate();
-  const [searchValue, setSearchValue] = React.useState('');
-  const [invalidSearch, setInvalidSearch] = useState(false);
+  const [searchValue, setSearchValue] = useState('');
 
   function submitHero(e) {
     e.preventDefault();
 
-    if (isValidSearch(searchValue)) {
-      setInvalidSearch(false);
-
-      navigate(`/${searchUrl}?${searchKey}=${searchValue}`);
-    } else {
-      setInvalidSearch(true);
-    }
+    navigate(`/${searchUrl}?${searchKey}=${searchValue}`);
   }
 
   return (
@@ -45,14 +36,11 @@ const Hero = ({
               style={{ flex: '1 1 100%', maxWidth: '100%' }}
             >
               <TextField
-                errorMessage={invalidSearch ? 'No special characters allowed. Please enter a valid search term.' : undefined}
-                errorPlacement='bottom'
                 label={textfieldLabel}
                 labelClassName="ds-u-visibility--screen-reader"
                 name="search_text_input"
                 style={{ maxWidth: 'none', height: '61px', margin: '0 20px 0 0' }}
                 onChange={(e) => {
-                  setInvalidSearch(false);
                   setSearchValue(e.target.value);
                 }}
               />

--- a/src/services/useSearchAPI/helpers.ts
+++ b/src/services/useSearchAPI/helpers.ts
@@ -54,5 +54,5 @@ export async function fetchDatasets(rootUrl: string, options: any, ACA?: string)
     page: page !== 1 ? page : undefined,  //use index except for when submitting to Search API
     ['page-size']: pageSize !== 10 ? pageSize : undefined,
   }
-  return await axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), {arrayFormat: 'comma',encode: false})}`)
+  return await axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), {arrayFormat: 'comma',encode: true})}`)
 }

--- a/src/services/useSearchAPI/useSearchAPI.test.jsx
+++ b/src/services/useSearchAPI/useSearchAPI.test.jsx
@@ -85,7 +85,7 @@ describe('useSearchAPI', () => {
     });
     await waitFor(() => expect(mockedAxios.get).toHaveBeenCalled());
     const url = mockedAxios.get.mock.calls[0][0];
-    expect(url).toContain('theme=Sales,Inventory');
+    expect(url).toContain('theme=Sales%2CInventory');
   });
 
   it('resetFilters clears fulltext and selectedFacets', async () => {

--- a/src/templates/DatasetList/DatasetList.tsx
+++ b/src/templates/DatasetList/DatasetList.tsx
@@ -108,7 +108,7 @@ const DatasetList = ({
   const { data, isPending, error } = useQuery({
     queryKey: ["datasets", params],
     queryFn: () => {
-      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: false })}`)
+      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: true })}`)
     }
   });
 

--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -17,10 +17,6 @@ import { DatasetSearchPageProps, SelectedFacetsType, SidebarFacetTypes, SearchRe
 import { acaToParams } from '../../utilities/aca';
 import { ACAContext } from '../../utilities/ACAContext';
 
-export const isValidSearch = (query: string) => {
-  return /^[a-zA-Z0-9 ]*$/.test(query.trim());
-};
-
 const sortOptions = [
   { label: 'Newest', value: 'newest' },
   { label: 'Oldest', value: 'oldest' },
@@ -82,7 +78,6 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
 
   // Local UI state only
   const [filterText, setFilterText] = useState(fulltext);
-  const [invalidSearch, setInvalidSearch] = useState<boolean>(false);
 
   // Sync filterText from URL on back/forward
   useEffect(() => { setFilterText(fulltext); }, [fulltext]);
@@ -217,14 +212,8 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
                 e.preventDefault();
 
                 if (filterText) {
-                  if (isValidSearch(filterText)) {
-                    setInvalidSearch(false);
-                    navigate({ search: buildNextQueryString({ fulltext: filterText, page: null }) });
-                  } else {
-                    setInvalidSearch(true);
-                  }
+                  navigate({ search: buildNextQueryString({ fulltext: filterText, page: null }) });
                 } else {
-                  setInvalidSearch(false);
                   navigate({ search: buildNextQueryString({ fulltext: null, page: null }) });
                 }
               }}
@@ -232,8 +221,6 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
             >
               <span className="ds-c-field__before fas fa-search ds-u-display--none ds-u-sm-display--inline-block" />
               <TextField
-                errorMessage={invalidSearch ? 'No special characters allowed. Please enter a valid search term.' : undefined}
-                errorPlacement='bottom'
                 fieldClassName="ds-u-margin--0"
                 value={filterText}
                 className={`ds-u-padding-right--2 ${altMobileSearchButton ? 'ds-l-col--12 ds-l-md-col--10 --alt-style' : 'ds-l-col--10'}`}
@@ -242,7 +229,6 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
                 placeholder="Search datasets"
                 name="dataset_fulltext_search"
                 onChange={(e) => {
-                  setInvalidSearch(false);
                   setFilterText(e.target.value)
                 }}
               />

--- a/src/templates/DatasetSearch/DatasetSearch.tsx
+++ b/src/templates/DatasetSearch/DatasetSearch.tsx
@@ -143,7 +143,7 @@ const DatasetSearch = (props: DatasetSearchPageProps) => {
   const { data, isPending } = useQuery({
     queryKey: ["datasets", params],
     queryFn: () => {
-      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: false })}`)
+      return axios.get(`${rootUrl}/search/?${qs.stringify(acaToParams(params, ACA), { arrayFormat: 'comma', encode: true })}`)
     }
   });
 

--- a/src/templates/DatasetSearch/dataset-search.scss
+++ b/src/templates/DatasetSearch/dataset-search.scss
@@ -41,8 +41,4 @@
     left: 16px;
     top: 12px;
   }
-
-  .ds-c-inline-error {
-    max-width: none;
-  }
 }

--- a/src/templates/DatasetSearch/datasetsearch.test.jsx
+++ b/src/templates/DatasetSearch/datasetsearch.test.jsx
@@ -301,26 +301,6 @@ describe('<DatasetSearch /> URL & Edge Cases', () => {
     expect(lastCall).not.toContain('fulltext');
   });
 
-  test('Invalid search blocks submission', async () => {
-    axios.get.mockClear();
-    await act(async () => {
-      renderWithProviders(<DatasetSearch rootUrl={rootUrl} />);
-    });
-    const callsBefore = axios.get.mock.calls.length;
-
-    const input = screen.getByRole('textbox', { name: 'Search datasets' });
-    await act(() => {
-      fireEvent.change(input, { target: { value: '!!@#$' } });
-    });
-    await act(() => {
-      fireEvent.submit(input.closest('form'));
-    });
-
-    expect(screen.getByText(/No special characters allowed/)).toBeInTheDocument();
-    // No new API call should have been triggered
-    expect(axios.get.mock.calls.length).toBe(callsBefore);
-  });
-
   test('Sort change updates URL and triggers API call', async () => {
     axios.get.mockClear();
     await act(async () => {


### PR DESCRIPTION
## JIRA Ticket(s)
- WCMS-28500: Ignore Special Characters in Search

## What
- Removed the "no special characters allowed" functionality from dataset search components (hero, header, /datasets).
- Updated unit tests.

## How to Test:
1. The downstream updates have been created with an alpha release and are already set up so you can test against those. The PR links are in the Jira ticket.
2. For each downstream PR, checkout `WCMS-28500-ignore-special-chars-in-search`.
3. Run 'ddev setup && ddev launch'.
4. From the homepage hero (if there is one), enter a search term that you know will yield results along with a few special characters and submit the search.
5. Verify that you are navigated to the search page with no special character error messages and that there are results for your search query. The results should be as if the special characters where never entered.
6. Remove the special characters from the search term in the search input and re-submit.
7. Verify that the same results are listed.
8. Open the search modal via "Search" button in the header and enter a search term that you know will yield results along with a few special characters and submit the search.
9. Verify that you are navigated to / stay on the search page with no special character error messages and that there are results for your search query. The results should be as if the special characters where never entered.
10. Clear all previous searches and being a fresh search on /datasets.
11. In the search input, enter a search term that you know will yield results along with a few special characters and submit the search.
12. Verify that you get no special character error messages and that there are results for your search query. The results should be as if the special characters where never entered.
13. Run 'ddev cypress' and all tests should pass.
14. Done.