### PR TITLE
Add optional toggle callbacks to FAQAccordion

### DIFF
--- a/COMPONENTS_INVENTORY.md
+++ b/COMPONENTS_INVENTORY.md
@@ -134,5 +134,5 @@ This document provides a comprehensive inventory of all components, services, te
 
 ---
 
-*Last updated: July 30, 2026*  
+*Last updated: August 5, 2026*  
 *Repository: [GetDKAN/cmsds-open-data-components](https://github.com/GetDKAN/cmsds-open-data-components)*

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@civicactions/cmsds-open-data-components",
-      "version": "4.4.0",
+      "version": "4.4.1",
       "license": "GPL-3.0",
       "dependencies": {
         "@civicactions/swagger-ui-layout": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@civicactions/cmsds-open-data-components",
-  "version": "4.4.0",
+  "version": "4.4.1",
   "description": "Components for the open data catalog frontend using CMS Design System",
   "main": "dist/main.js",
   "source": "src/index.ts",

--- a/src/components/FAQAccordion/FAQAccordion.stories.tsx
+++ b/src/components/FAQAccordion/FAQAccordion.stories.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import type { StoryFn, StoryContext } from '@storybook/react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from 'storybook/test';
 import FAQAccordion from './index';
 import type { FAQItemType } from '../../types/misc';
 
@@ -24,29 +24,56 @@ const sampleFaqs: FAQItemType[] = [
   },
 ];
 
-export default {
+const meta: Meta<typeof FAQAccordion> = {
   title: 'Components/FAQAccordion',
   component: FAQAccordion,
   tags: ['autodocs'],
+  args: {
+    faqs: sampleFaqs,
+    onItemToggle: fn(),
+    onToggleAll: fn(),
+  },
   argTypes: {
     faqs: {
       control: 'object',
       description: 'Array of FAQ items to display.',
-      defaultValue: sampleFaqs,
+    },
+    onItemToggle: {
+      description:
+        'Invoked whenever a single FAQ item is expanded or collapsed. Receives the item `id` and its new open state. Not invoked by the expand/collapse all button.',
+      table: { category: 'Events' },
+    },
+    onToggleAll: {
+      description:
+        'Invoked when the "Expand/Collapse all FAQs" button is used. Receives the new open state applied to every item.',
+      table: { category: 'Events' },
     },
   },
   parameters: {
     docs: {
       description: {
-        component: 'Displays an accordion of FAQ items with expand/collapse all functionality.'
+        component:
+          'Displays an accordion of FAQ items with expand/collapse all functionality. Toggle events are reported through `onItemToggle` and `onToggleAll` \u2014 open the Actions panel to watch them fire.'
       }
     }
   },
 };
 
-export const Default = {
+export default meta;
+type Story = StoryObj<typeof FAQAccordion>;
+
+export const Default: Story = {};
+
+export const PreExpanded: Story = {
   args: {
-    faqs: sampleFaqs,
+    faqs: sampleFaqs.map((faq) => ({ ...faq, open: true })),
   },
-  render: (args: { faqs: FAQItemType[] }) => <FAQAccordion {...args} />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Items supplied with `open: true`. The toggle-all button still starts on "Expand all FAQs" because its label tracks internal state rather than the incoming items, so the first click reports `onToggleAll(true)` on already-open items.'
+      }
+    }
+  },
 };

--- a/src/components/FAQAccordion/FAQAccordion.test.tsx
+++ b/src/components/FAQAccordion/FAQAccordion.test.tsx
@@ -46,4 +46,77 @@ describe('FAQAccordion', () => {
     await user.click(screen.getByRole('button', { name: 'Question one' }));
     expect(screen.getByRole('button', { name: 'Expand all FAQs' })).toBeInTheDocument();
   });
+
+  describe('callbacks', () => {
+    const onItemToggle = jest.fn();
+    const onToggleAll = jest.fn();
+
+    beforeEach(() => {
+      onItemToggle.mockClear();
+      onToggleAll.mockClear();
+    });
+
+    it('reports the item id and new open state when an item is expanded', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} onItemToggle={onItemToggle} />);
+      await user.click(screen.getByRole('button', { name: 'Question one' }));
+      expect(onItemToggle).toHaveBeenCalledTimes(1);
+      expect(onItemToggle).toHaveBeenCalledWith('a', true);
+    });
+
+    it('reports the collapsed state when the same item is toggled twice', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} onItemToggle={onItemToggle} />);
+      const button = screen.getByRole('button', { name: 'Question one' });
+      await user.click(button);
+      await user.click(button);
+      expect(onItemToggle).toHaveBeenCalledTimes(2);
+      expect(onItemToggle).toHaveBeenNthCalledWith(2, 'a', false);
+    });
+
+    it('reports true when expand all is used', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} onToggleAll={onToggleAll} />);
+      await user.click(screen.getByRole('button', { name: 'Expand all FAQs' }));
+      expect(onToggleAll).toHaveBeenCalledTimes(1);
+      expect(onToggleAll).toHaveBeenCalledWith(true);
+    });
+
+    it('reports false when collapse all is used', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} onToggleAll={onToggleAll} />);
+      await user.click(screen.getByRole('button', { name: 'Expand all FAQs' }));
+      await user.click(screen.getByRole('button', { name: 'Collapse all FAQs' }));
+      expect(onToggleAll).toHaveBeenNthCalledWith(2, false);
+    });
+
+    it('does not emit per-item events when toggling all', async () => {
+      const user = userEvent.setup();
+      render(
+        <FAQAccordion faqs={faqs} onItemToggle={onItemToggle} onToggleAll={onToggleAll} />
+      );
+      await user.click(screen.getByRole('button', { name: 'Expand all FAQs' }));
+      expect(onToggleAll).toHaveBeenCalledWith(true);
+      expect(onItemToggle).not.toHaveBeenCalled();
+    });
+
+    it('reports false from the toggle all button after every item was opened individually', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} onToggleAll={onToggleAll} />);
+      await user.click(screen.getByRole('button', { name: 'Question one' }));
+      await user.click(screen.getByRole('button', { name: 'Question two' }));
+      await user.click(screen.getByRole('button', { name: 'Question three' }));
+      await user.click(screen.getByRole('button', { name: 'Collapse all FAQs' }));
+      expect(onToggleAll).toHaveBeenCalledTimes(1);
+      expect(onToggleAll).toHaveBeenCalledWith(false);
+    });
+
+    it('toggles without throwing when no callbacks are supplied', async () => {
+      const user = userEvent.setup();
+      render(<FAQAccordion faqs={faqs} />);
+      await user.click(screen.getByRole('button', { name: 'Question one' }));
+      await user.click(screen.getByRole('button', { name: 'Expand all FAQs' }));
+      expect(screen.getByRole('button', { name: 'Collapse all FAQs' })).toBeInTheDocument();
+    });
+  });
 });

--- a/src/components/FAQAccordion/index.tsx
+++ b/src/components/FAQAccordion/index.tsx
@@ -4,10 +4,14 @@ import { Accordion, AccordionItem, Button } from "@cmsgov/design-system";
 
 type FAQProps = {
   faqs: FAQItemType[]
+  /** Invoked whenever a single FAQ item is expanded or collapsed. */
+  onItemToggle?: (id: string, isOpen: boolean) => void
+  /** Invoked when the "Expand/Collapse all FAQs" button is used. */
+  onToggleAll?: (isOpen: boolean) => void
 }
 
 const FAQAccordion = (props: FAQProps) => {
-  const { faqs } = props;
+  const { faqs, onItemToggle, onToggleAll } = props;
   const [expanded, setExpanded] = React.useState(false);
   const [faqItems, setFaqItems] = React.useState(faqs);
 
@@ -16,14 +20,16 @@ const FAQAccordion = (props: FAQProps) => {
       const newFaqs = faqItems.map((item) => ({...item, open: false}));
       setFaqItems(newFaqs);
       setExpanded(false);
+      onToggleAll?.(false);
     } else {
       const newFaqs = faqItems.map((item) => ({...item, open: true}));
       setFaqItems(newFaqs);
       setExpanded(true);
+      onToggleAll?.(true);
     }
   }
 
-  function toggleAccordionItem(id: string) {
+   function toggleAccordionItem(id: string) {
     const currentFaqIndex = faqItems.findIndex((item) => item.id === id);
     const updatedFaq = {
       ...faqItems[currentFaqIndex],
@@ -43,6 +49,8 @@ const FAQAccordion = (props: FAQProps) => {
     } else {
       setExpanded(false);
     }
+
+    onItemToggle?.(id, updatedFaq.open);
   }
 
   return(


### PR DESCRIPTION
Enhance FAQAccordion with toggle callbacks and update tests for event reporting

Testing:
- Checkout branch an run `npm i`
- run `npm test` from the terminal and verify all unit tests pass
- run `npm run storybook` to launch storybook
- click on the FAQAccordion story
- Select the Default story for FAQAccordion and click on the Actions panel at the bottom of the screen.
- Click a few accordion items and the Expand all button in the story.
- Verify events are logged in the actions panel when those controls are clicked.
- Example:

<img width="1253" height="623" alt="Screenshot 2026-08-05 at 11 07 43 AM" src="https://github.com/user-attachments/assets/88da3423-bf02-4d31-9df5-8263ad929578" />
